### PR TITLE
Improve handler generation

### DIFF
--- a/src/main/resources/serviceproxy/template/handlergen.templ
+++ b/src/main/resources/serviceproxy/template/handlergen.templ
@@ -19,11 +19,14 @@ import @{ifaceFQCN};\n
 import io.vertx.core.Vertx;\n
 import io.vertx.core.Handler;\n
 import io.vertx.core.AsyncResult;\n
+import io.vertx.core.eventbus.EventBus;\n
 import io.vertx.core.eventbus.Message;\n
+import io.vertx.core.eventbus.MessageConsumer;\n
 import io.vertx.core.eventbus.DeliveryOptions;\n
 import io.vertx.core.eventbus.ReplyException;\n
 import io.vertx.core.json.JsonObject;\n
 import io.vertx.core.json.JsonArray;\n
+import java.util.Collection;\n
 import java.util.ArrayList;\n
 import java.util.HashSet;\n
 import java.util.List;\n
@@ -45,12 +48,23 @@ import io.vertx.serviceproxy.ProxyHandler;\n
 */\n
 public class @{ifaceSimpleName}VertxProxyHandler extends ProxyHandler {\n
 \n
+  public static final long DEFAULT_CONNECTION_TIMEOUT = 5 * 60; // 5 minutes \n
+\n
   private final Vertx vertx;\n
   private final @{ifaceSimpleName} service;\n
   private final String address;\n
   private final long timerID;\n
   private long lastAccessed;\n
   private final long timeoutSeconds;\n
+\n
+  public @{ifaceSimpleName}VertxProxyHandler(Vertx vertx, @{ifaceSimpleName} service, String address) {\n
+    this(vertx, service, address, DEFAULT_CONNECTION_TIMEOUT);
+  }\n
+\n
+  public @{ifaceSimpleName}VertxProxyHandler(Vertx vertx, @{ifaceSimpleName} service, String address,\n
+    long timeoutInSecond) {\n
+    this(vertx, service, address, true, timeoutInSecond);\n
+  }\n
 \n
   public @{ifaceSimpleName}VertxProxyHandler(Vertx vertx, @{ifaceSimpleName} service, String address, boolean topLevel, long timeoutSeconds) {\n
     this.vertx = vertx;\n
@@ -67,6 +81,22 @@ public class @{ifaceSimpleName}VertxProxyHandler extends ProxyHandler {\n
       this.timerID = -1;\n
     }\n
     accessed();\n
+  }\n
+\n
+  public <T> MessageConsumer<JsonObject> registerHandler() {\n
+    MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);\n
+    this.setConsumer(consumer);\n
+    return consumer;\n
+  }\n
+\n
+  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {\n
+    List<MessageConsumer<JsonObject>> list = new ArrayList<>();\n
+    for (EventBus bus : buses) {\n
+      MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);\n
+      this.setConsumer(consumer);\n
+      list.add(consumer);\n
+    }\n
+    return list;\n
   }\n
 \n
   private void checkTimedOut(long id) {\n

--- a/src/main/resources/serviceproxy/template/handlergen.templ
+++ b/src/main/resources/serviceproxy/template/handlergen.templ
@@ -83,13 +83,13 @@ public class @{ifaceSimpleName}VertxProxyHandler extends ProxyHandler {\n
     accessed();\n
   }\n
 \n
-  public <T> MessageConsumer<JsonObject> registerHandler() {\n
+  public MessageConsumer<JsonObject> registerHandler() {\n
     MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);\n
     this.setConsumer(consumer);\n
     return consumer;\n
   }\n
 \n
-  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {\n
+  public Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {\n
     List<MessageConsumer<JsonObject>> list = new ArrayList<>();\n
     for (EventBus bus : buses) {\n
       MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);\n

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxProxyHandler.java
@@ -78,13 +78,13 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
     accessed();
   }
 
-  public <T> MessageConsumer<JsonObject> registerHandler() {
+  public MessageConsumer<JsonObject> registerHandler() {
     MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);
     this.setConsumer(consumer);
     return consumer;
   }
 
-  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
+  public Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
     List<MessageConsumer<JsonObject>> list = new ArrayList<>();
     for (EventBus bus : buses) {
       MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
@@ -20,11 +20,14 @@ import io.vertx.serviceproxy.testmodel.TestConnection;
 import io.vertx.core.Vertx;
 import io.vertx.core.Handler;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.util.Collection;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -45,12 +48,22 @@ import io.vertx.core.Handler;
 */
 public class TestConnectionVertxProxyHandler extends ProxyHandler {
 
+  public static final long DEFAULT_CONNECTION_TIMEOUT = 5 * 60; // 5 minutes 
+
   private final Vertx vertx;
   private final TestConnection service;
   private final String address;
   private final long timerID;
   private long lastAccessed;
   private final long timeoutSeconds;
+
+  public TestConnectionVertxProxyHandler(Vertx vertx, TestConnection service, String address) {
+    this(vertx, service, address, DEFAULT_CONNECTION_TIMEOUT);  }
+
+  public TestConnectionVertxProxyHandler(Vertx vertx, TestConnection service, String address,
+    long timeoutInSecond) {
+    this(vertx, service, address, true, timeoutInSecond);
+  }
 
   public TestConnectionVertxProxyHandler(Vertx vertx, TestConnection service, String address, boolean topLevel, long timeoutSeconds) {
     this.vertx = vertx;
@@ -67,6 +80,22 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
       this.timerID = -1;
     }
     accessed();
+  }
+
+  public <T> MessageConsumer<JsonObject> registerHandler() {
+    MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);
+    this.setConsumer(consumer);
+    return consumer;
+  }
+
+  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
+    List<MessageConsumer<JsonObject>> list = new ArrayList<>();
+    for (EventBus bus : buses) {
+      MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);
+      this.setConsumer(consumer);
+      list.add(consumer);
+    }
+    return list;
   }
 
   private void checkTimedOut(long id) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
@@ -82,13 +82,13 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
     accessed();
   }
 
-  public <T> MessageConsumer<JsonObject> registerHandler() {
+  public MessageConsumer<JsonObject> registerHandler() {
     MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);
     this.setConsumer(consumer);
     return consumer;
   }
 
-  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
+  public Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
     List<MessageConsumer<JsonObject>> list = new ArrayList<>();
     for (EventBus bus : buses) {
       MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
@@ -20,11 +20,14 @@ import io.vertx.serviceproxy.testmodel.TestConnectionWithCloseFuture;
 import io.vertx.core.Vertx;
 import io.vertx.core.Handler;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.util.Collection;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -43,12 +46,22 @@ import io.vertx.core.Handler;
 */
 public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler {
 
+  public static final long DEFAULT_CONNECTION_TIMEOUT = 5 * 60; // 5 minutes 
+
   private final Vertx vertx;
   private final TestConnectionWithCloseFuture service;
   private final String address;
   private final long timerID;
   private long lastAccessed;
   private final long timeoutSeconds;
+
+  public TestConnectionWithCloseFutureVertxProxyHandler(Vertx vertx, TestConnectionWithCloseFuture service, String address) {
+    this(vertx, service, address, DEFAULT_CONNECTION_TIMEOUT);  }
+
+  public TestConnectionWithCloseFutureVertxProxyHandler(Vertx vertx, TestConnectionWithCloseFuture service, String address,
+    long timeoutInSecond) {
+    this(vertx, service, address, true, timeoutInSecond);
+  }
 
   public TestConnectionWithCloseFutureVertxProxyHandler(Vertx vertx, TestConnectionWithCloseFuture service, String address, boolean topLevel, long timeoutSeconds) {
     this.vertx = vertx;
@@ -65,6 +78,22 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
       this.timerID = -1;
     }
     accessed();
+  }
+
+  public <T> MessageConsumer<JsonObject> registerHandler() {
+    MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);
+    this.setConsumer(consumer);
+    return consumer;
+  }
+
+  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
+    List<MessageConsumer<JsonObject>> list = new ArrayList<>();
+    for (EventBus bus : buses) {
+      MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);
+      this.setConsumer(consumer);
+      list.add(consumer);
+    }
+    return list;
   }
 
   private void checkTimedOut(long id) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
@@ -80,13 +80,13 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
     accessed();
   }
 
-  public <T> MessageConsumer<JsonObject> registerHandler() {
+  public MessageConsumer<JsonObject> registerHandler() {
     MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);
     this.setConsumer(consumer);
     return consumer;
   }
 
-  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
+  public Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
     List<MessageConsumer<JsonObject>> list = new ArrayList<>();
     for (EventBus bus : buses) {
       MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
@@ -91,13 +91,13 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
     accessed();
   }
 
-  public <T> MessageConsumer<JsonObject> registerHandler() {
+  public MessageConsumer<JsonObject> registerHandler() {
     MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);
     this.setConsumer(consumer);
     return consumer;
   }
 
-  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
+  public Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
     List<MessageConsumer<JsonObject>> list = new ArrayList<>();
     for (EventBus bus : buses) {
       MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
@@ -20,11 +20,14 @@ import io.vertx.serviceproxy.testmodel.TestService;
 import io.vertx.core.Vertx;
 import io.vertx.core.Handler;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.eventbus.EventBus;
 import io.vertx.core.eventbus.Message;
+import io.vertx.core.eventbus.MessageConsumer;
 import io.vertx.core.eventbus.DeliveryOptions;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.json.JsonArray;
+import java.util.Collection;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -54,12 +57,22 @@ import io.vertx.core.Handler;
 */
 public class TestServiceVertxProxyHandler extends ProxyHandler {
 
+  public static final long DEFAULT_CONNECTION_TIMEOUT = 5 * 60; // 5 minutes 
+
   private final Vertx vertx;
   private final TestService service;
   private final String address;
   private final long timerID;
   private long lastAccessed;
   private final long timeoutSeconds;
+
+  public TestServiceVertxProxyHandler(Vertx vertx, TestService service, String address) {
+    this(vertx, service, address, DEFAULT_CONNECTION_TIMEOUT);  }
+
+  public TestServiceVertxProxyHandler(Vertx vertx, TestService service, String address,
+    long timeoutInSecond) {
+    this(vertx, service, address, true, timeoutInSecond);
+  }
 
   public TestServiceVertxProxyHandler(Vertx vertx, TestService service, String address, boolean topLevel, long timeoutSeconds) {
     this.vertx = vertx;
@@ -76,6 +89,22 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
       this.timerID = -1;
     }
     accessed();
+  }
+
+  public <T> MessageConsumer<JsonObject> registerHandler() {
+    MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>consumer(address).handler(this);
+    this.setConsumer(consumer);
+    return consumer;
+  }
+
+  public <T> Collection<MessageConsumer<JsonObject>> registerHandler(EventBus... buses) {
+    List<MessageConsumer<JsonObject>> list = new ArrayList<>();
+    for (EventBus bus : buses) {
+      MessageConsumer<JsonObject> consumer = bus.<JsonObject>consumer(address).handler(this);
+      this.setConsumer(consumer);
+      list.add(consumer);
+    }
+    return list;
   }
 
   private void checkTimedOut(long id) {


### PR DESCRIPTION
Improve handler generation  by adding two methods to register the handler on the event bus (or a selected set of event buses)

So no need to use the ProxyHelper anymore.

@vietj please review.

Signed-off-by: Clement Escoffier <clement.escoffier@gmail.com>