### PR TITLE
Fix example of nested ProxyGen - needed @VertxGen

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ return a connection interface, e.g.
 Where:
 
     @ProxyGen
+    @VertxGen
     public interface MyDatabaseConnection {
     
         void insert(JsonObject someData);


### PR DESCRIPTION
The given example can't compile with non-static methods unless it is annotated with @VertxGen.