### PR TITLE
Class cast exceptions when json arrays contain maps

### DIFF
--- a/src/main/resources/serviceproxy/template/proxygen.templ
+++ b/src/main/resources/serviceproxy/template/proxygen.templ
@@ -74,7 +74,7 @@ send(_address, _json, _deliveryOptions, res -> {\n
 					@if{resultType.args[0].name == 'java.lang.Character'}
         @{lastParam.name}.handle(Future.succeededFuture(convertToListChar(res.result().body())));\n
 					@else{resultType.args[0].kind == CLASS_DATA_OBJECT}
-        @{lastParam.name}.handle(Future.succeededFuture(res.result().body().stream().map(o -> new @{resultType.args[0].simpleName}((JsonObject)o)).collect(Collectors.toList())));\n
+        @{lastParam.name}.handle(Future.succeededFuture(res.result().body().stream().map(o -> o instanceof Map ? new @{resultType.args[0].simpleName}(new JsonObject((Map) o)) : new @{resultType.args[0].simpleName}((JsonObject) o)).collect(Collectors.toList())));\n
 					@else{}
         @{lastParam.name}.handle(Future.succeededFuture(convertList(res.result().body().getList())));\n
 					@end{}
@@ -82,7 +82,7 @@ send(_address, _json, _deliveryOptions, res -> {\n
 					@if{resultType.args[0].name == 'java.lang.Character'}
         @{lastParam.name}.handle(Future.succeededFuture(convertToSetChar(res.result().body())));\n
 					@else{resultType.args[0].kind == CLASS_DATA_OBJECT}
-        @{lastParam.name}.handle(Future.succeededFuture(res.result().body().stream().map(o -> new @{resultType.args[0].simpleName}((JsonObject)o)).collect(Collectors.toSet())));\n
+        @{lastParam.name}.handle(Future.succeededFuture(res.result().body().stream().map(o -> o instanceof Map ? new @{resultType.args[0].simpleName}(new JsonObject((Map) o)) : new @{resultType.args[0].simpleName}((JsonObject) o)).collect(Collectors.toSet())));\n
 					@else{}
         @{lastParam.name}.handle(Future.succeededFuture(convertSet(res.result().body().getList())));\n
 					@end{}

--- a/src/test/asciidoc/cheatsheet/TestDataObject.adoc
+++ b/src/test/asciidoc/cheatsheet/TestDataObject.adoc
@@ -14,7 +14,7 @@
 |`Boolean`
 |-
 |[[number]]`number`
-|`Number`
+|`Number (int)`
 |-
 |[[string]]`string`
 |`String`

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxEBProxy.java
@@ -1016,7 +1016,7 @@ public class TestServiceVertxEBProxy implements TestService {
       if (res.failed()) {
         resultHandler.handle(Future.failedFuture(res.cause()));
       } else {
-        resultHandler.handle(Future.succeededFuture(res.result().body().stream().map(o -> new TestDataObject((JsonObject)o)).collect(Collectors.toList())));
+        resultHandler.handle(Future.succeededFuture(res.result().body().stream().map(o -> o instanceof Map ? new TestDataObject(new JsonObject((Map) o)) : new TestDataObject((JsonObject) o)).collect(Collectors.toList())));
       }
     });
   }
@@ -1220,7 +1220,7 @@ public class TestServiceVertxEBProxy implements TestService {
       if (res.failed()) {
         resultHandler.handle(Future.failedFuture(res.cause()));
       } else {
-        resultHandler.handle(Future.succeededFuture(res.result().body().stream().map(o -> new TestDataObject((JsonObject)o)).collect(Collectors.toSet())));
+        resultHandler.handle(Future.succeededFuture(res.result().body().stream().map(o -> o instanceof Map ? new TestDataObject(new JsonObject((Map) o)) : new TestDataObject((JsonObject) o)).collect(Collectors.toSet())));
       }
     });
   }


### PR DESCRIPTION
_This is a weird issue_

When running in distributed mode (so with -cluster) and with a service with such a method:

```
  void getAll(Handler<AsyncResult<List<Data>>> handler);
```

(`Data` is a valid data object)

The proxy client cannot retrieve the result because it get a class cast exception. The generated code expects to receive a `JsonArray` with only `JsonObject`. This is true in local, but in remote, the `JsonArray` contains `LinkedHashMap`. I suspect an issue in the codec.

This commit is a fix for this case in the proxy template. It checks whether the object is an instance of map, and in this case, it creates the `JsonObject` and then creates the data object instance from the created `JsonObject`. Otherwise, the data object instance is created from the given `JsonObject`. 