### PR TITLE
Convert element within nested list and map.

### DIFF
--- a/src/main/resources/serviceproxy/template/proxygen.templ
+++ b/src/main/resources/serviceproxy/template/proxygen.templ
@@ -143,6 +143,7 @@ import java.util.List;\n
 import java.util.Map;\n
 import java.util.Set;\n
 import java.util.stream.Collectors;\n
+import java.util.function.Function;\n
 import io.vertx.serviceproxy.ProxyHelper;\n
 @foreach{importedType:importedTypes}
 	@if{!importedType.packageName.equals("java.lang")}
@@ -203,15 +204,47 @@ public class @{ifaceSimpleName}VertxEBProxy implements @{ifaceSimpleName} {\n
   }\n\n
 
   private <T> Map<String, T> convertMap(Map map) {\n
-    return (Map<String, T>)map;\n
+    if (map.isEmpty()) { \n
+      return (Map<String, T>) map; \n
+    } \n
+     \n
+    Object elem = map.values().stream().findFirst().get(); \n
+    if (!(elem instanceof Map) && !(elem instanceof List)) { \n
+      return (Map<String, T>) map; \n
+    } else { \n
+      Function<Object, T> converter; \n
+      if (elem instanceof List) { \n
+        converter = object -> (T) new JsonArray((List) object); \n
+      } else { \n
+        converter = object -> (T) new JsonObject((Map) object); \n
+      } \n
+      return ((Map<String, T>) map).entrySet() \n
+       .stream() \n
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); \n
+    } \n
   }\n
 
   private <T> List<T> convertList(List list) {\n
-    return (List<T>)list;\n
+    if (list.isEmpty()) { \n
+          return (List<T>) list; \n
+        } \n
+     \n
+    Object elem = list.get(0); \n
+    if (!(elem instanceof Map) && !(elem instanceof List)) { \n
+      return (List<T>) list; \n
+    } else { \n
+      Function<Object, T> converter; \n
+      if (elem instanceof List) { \n
+        converter = object -> (T) new JsonArray((List) object); \n
+      } else { \n
+        converter = object -> (T) new JsonObject((Map) object); \n
+      } \n
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); \n
+    } \n
   }\n
 
   private <T> Set<T> convertSet(List list) {\n
-    return new HashSet<T>((List<T>)list);\n
+    return new HashSet<T>(convertList(list));\n
   }\n
 
 }

--- a/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxProxyHandler.java
@@ -169,6 +169,10 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
          });
           break;
         }
+        case "methodWithListOfJsonObject": {
+          service.methodWithListOfJsonObject(convertList(json.getJsonArray("list").getList()), createListHandler(msg));
+          break;
+        }
         default: {
           throw new IllegalStateException("Invalid action: " + action);
         }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxEBProxy.java
@@ -82,7 +82,24 @@ public class TestBaseImportsServiceVertxEBProxy implements TestBaseImportsServic
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
   private <T> List<T> convertList(List list) {
     if (list.isEmpty()) { 
@@ -95,14 +112,14 @@ public class TestBaseImportsServiceVertxEBProxy implements TestBaseImportsServic
     } else { 
       Function<Object, T> converter; 
       if (elem instanceof List) { 
-        converter = object -> (T) new JsonArray((List) elem); 
+        converter = object -> (T) new JsonArray((List) object); 
       } else { 
-        converter = object -> (T) new JsonObject((Map) elem); 
+        converter = object -> (T) new JsonObject((Map) object); 
       } 
       return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
     } 
   }
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxEBProxy.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 
 /*
@@ -84,7 +85,22 @@ public class TestBaseImportsServiceVertxEBProxy implements TestBaseImportsServic
     return (Map<String, T>)map;
   }
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) elem); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) elem); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
   private <T> Set<T> convertSet(List list) {
     return new HashSet<T>((List<T>)list);

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxEBProxy.java
@@ -161,7 +161,24 @@ public class TestConnectionVertxEBProxy implements TestConnection {
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
   private <T> List<T> convertList(List list) {
     if (list.isEmpty()) { 
@@ -174,14 +191,14 @@ public class TestConnectionVertxEBProxy implements TestConnection {
     } else { 
       Function<Object, T> converter; 
       if (elem instanceof List) { 
-        converter = object -> (T) new JsonArray((List) elem); 
+        converter = object -> (T) new JsonArray((List) object); 
       } else { 
-        converter = object -> (T) new JsonObject((Map) elem); 
+        converter = object -> (T) new JsonObject((Map) object); 
       } 
       return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
     } 
   }
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxEBProxy.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.testmodel.TestConnection;
@@ -163,7 +164,22 @@ public class TestConnectionVertxEBProxy implements TestConnection {
     return (Map<String, T>)map;
   }
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) elem); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) elem); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
   private <T> Set<T> convertSet(List list) {
     return new HashSet<T>((List<T>)list);

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxEBProxy.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
@@ -111,7 +112,22 @@ public class TestConnectionWithCloseFutureVertxEBProxy implements TestConnection
     return (Map<String, T>)map;
   }
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) elem); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) elem); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
   private <T> Set<T> convertSet(List list) {
     return new HashSet<T>((List<T>)list);

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxEBProxy.java
@@ -109,7 +109,24 @@ public class TestConnectionWithCloseFutureVertxEBProxy implements TestConnection
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
   private <T> List<T> convertList(List list) {
     if (list.isEmpty()) { 
@@ -122,14 +139,14 @@ public class TestConnectionWithCloseFutureVertxEBProxy implements TestConnection
     } else { 
       Function<Object, T> converter; 
       if (elem instanceof List) { 
-        converter = object -> (T) new JsonArray((List) elem); 
+        converter = object -> (T) new JsonArray((List) object); 
       } else { 
-        converter = object -> (T) new JsonObject((Map) elem); 
+        converter = object -> (T) new JsonObject((Map) object); 
       } 
       return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
     } 
   }
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxEBProxy.java
@@ -1283,7 +1283,24 @@ public class TestServiceVertxEBProxy implements TestService {
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
   private <T> List<T> convertList(List list) {
     if (list.isEmpty()) { 
@@ -1296,14 +1313,14 @@ public class TestServiceVertxEBProxy implements TestService {
     } else { 
       Function<Object, T> converter; 
       if (elem instanceof List) { 
-        converter = object -> (T) new JsonArray((List) elem); 
+        converter = object -> (T) new JsonArray((List) object); 
       } else { 
-        converter = object -> (T) new JsonObject((Map) elem); 
+        converter = object -> (T) new JsonObject((Map) object); 
       } 
       return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
     } 
   }
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxEBProxy.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.testmodel.TestService;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
@@ -1285,7 +1286,22 @@ public class TestServiceVertxEBProxy implements TestService {
     return (Map<String, T>)map;
   }
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) elem); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) elem); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
   private <T> Set<T> convertSet(List list) {
     return new HashSet<T>((List<T>)list);

--- a/src/test/java/io/vertx/serviceproxy/clustered/Service.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/Service.java
@@ -58,4 +58,12 @@ public interface Service {
   Service methodWithListOfDataObject(List<TestDataObject> list,
                                      Handler<AsyncResult<List<TestDataObject>>> result);
 
+  @Fluent
+  Service methodWithListOfJsonObject(List<JsonObject> list,
+                                     Handler<AsyncResult<List<JsonObject>>> result);
+
+  /*@Fluent
+  Service methodWithMapOfJsonObject(Map<String, JsonObject> map,
+                                    Handler<AsyncResult<Map<String, JsonObject>>> result);
+*/
 }

--- a/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
@@ -73,4 +73,16 @@ public class ServiceProvider implements Service {
     result.handle(Future.succeededFuture(list));
     return this;
   }
+
+  @Override
+  public Service methodWithListOfJsonObject(List<JsonObject> list, Handler<AsyncResult<List<JsonObject>>> result) {
+    result.handle(Future.succeededFuture(list));
+    return this;
+  }
+
+  /*@Override
+  public Service methodWithMapOfJsonObject(Map<String, JsonObject> map, Handler<AsyncResult<Map<String, JsonObject>>> result) {
+    result.handle(Future.succeededFuture(map));
+    return this;
+  }*/
 }

--- a/src/test/resources/test-js/service-proxy.js
+++ b/src/test/resources/test-js/service-proxy.js
@@ -205,6 +205,24 @@
       } else throw new TypeError('function invoked with invalid arguments');
     };
 
+    /**
+
+     @public
+     @param list {Array.<Object>} 
+     @param result {function} 
+     @return {Service}
+     */
+    this.methodWithListOfJsonObject = function(list, result) {
+      var __args = arguments;
+      if (__args.length === 2 && typeof __args[0] === 'object' && __args[0] instanceof Array && typeof __args[1] === 'function') {
+        if (closed) {
+          throw new Error('Proxy is closed');
+        }
+        j_eb.send(j_address, {"list":__args[0]}, {"action":"methodWithListOfJsonObject"}, function(err, result) { __args[1](err, result &&result.body); });
+        return that;
+      } else throw new TypeError('function invoked with invalid arguments');
+    };
+
   };
 
   /**

--- a/src/test/resources/test-js/service.js
+++ b/src/test/resources/test-js/service.js
@@ -219,6 +219,27 @@ var Service = function(j_val) {
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
+  /**
+
+   @public
+   @param list {Array.<Object>} 
+   @param result {function} 
+   @return {Service}
+   */
+  this.methodWithListOfJsonObject = function(list, result) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'object' && __args[0] instanceof Array && typeof __args[1] === 'function') {
+      j_service["methodWithListOfJsonObject(java.util.List,io.vertx.core.Handler)"](utils.convParamListJsonObject(list), function(ar) {
+      if (ar.succeeded()) {
+        result(utils.convReturnListSetJson(ar.result()), null);
+      } else {
+        result(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
   // A reference to the underlying Java delegate
   // NOTE! This is an internal API and must not be used in user code.
   // If you rely on this property your code is likely to break if we change it / remove it without warning.


### PR DESCRIPTION
The mongo service proxy violates some method signatures when running over a cluster of several node.

For instance, the method:
```java
MongoClient find(String collection, JsonObject query, Handler<AsyncResult<List<JsonObject>>> resultHandler);
```

Doesn't return a instance of `List<JsonObject>` but a `List<Map>` instance instead.

I've tried to explain the issue in this topic: https://groups.google.com/d/topic/vertx/7pMZEMsjZNE/discussion

According to the documentation of `vertx-service-proxy`, you can only have  `JsonObject` or `JsonArray` contained in instances of `Map`, `List` or `Set`.

So, now in `convertList` and `convertMap` the code:
- returns the collection if it's empty
- fetches an element of the collection :
   - if it's already an instance of `JsonObject` or `JsonArray`, the collection is returned directly modified.
   - if it's something else (so a `Map` or a `List`), the code will rebuild a new collection by wrapping these instances into `JsonObject` or `JsonArray` respectively.