### PR TITLE
Add registerLocalHandler support

### DIFF
--- a/src/main/java/io/vertx/serviceproxy/ProxyHandler.java
+++ b/src/main/java/io/vertx/serviceproxy/ProxyHandler.java
@@ -46,4 +46,14 @@ public abstract class ProxyHandler implements Handler<Message<JsonObject>> {
    */
   public abstract MessageConsumer<JsonObject> registerHandler(String address);
 
+
+  /**
+   * Register the local proxy handle on the event bus.
+   * The registration will not be propagated to other nodes in the cluster.
+   *
+   * @param address the proxy address
+   * @return the registered message consumer
+   */
+  public abstract MessageConsumer<JsonObject> registerLocalHandler(String address);
+
 }

--- a/src/main/resources/serviceproxy/template/handlergen.templ
+++ b/src/main/resources/serviceproxy/template/handlergen.templ
@@ -102,6 +102,12 @@ public class @{ifaceSimpleName}VertxProxyHandler extends ProxyHandler {\n
     return consumer;\n
   }\n
 \n
+  public MessageConsumer<JsonObject> registerLocalHandler(String address) {\n
+    MessageConsumer<JsonObject> consumer = vertx.eventBus().<JsonObject>localConsumer(address).handler(this);\n
+    this.setConsumer(consumer);\n
+    return consumer;\n
+  }\n
+\n
   private void checkTimedOut(long id) {\n
     long now = System.nanoTime();\n
     if (now - lastAccessed > timeoutSeconds * 1000000000) {\n

--- a/src/test/java/io/vertx/serviceproxy/clustered/ClusteredTest.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/ClusteredTest.java
@@ -208,7 +208,7 @@ public class ClusteredTest {
       assertThat(exception.failureType()).isEqualTo(ReplyFailure.NO_HANDLERS);
       result.set(ar.cause());
     });
-    Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> result.get() != null);
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> result.get() != null);
   }
 
 }

--- a/src/test/java/io/vertx/serviceproxy/clustered/LocalServiceProviderVerticle.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/LocalServiceProviderVerticle.java
@@ -1,0 +1,16 @@
+package io.vertx.serviceproxy.clustered;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.serviceproxy.ProxyHelper;
+
+/**
+ * @author <a href="https://github.com/michalboska">Michal Boska</a>
+ */
+public class LocalServiceProviderVerticle extends AbstractVerticle {
+
+
+  @Override
+  public void start() throws Exception {
+    ProxyHelper.registerLocalService(Service.class, vertx, new ServiceProvider(), "my.local.service");
+  }
+}

--- a/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
+++ b/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
@@ -42,18 +42,22 @@ import java.util.stream.Collectors;
 public class ServiceProxyTest extends VertxTestBase {
 
   public final static String SERVICE_ADDRESS = "someaddress";
+  public final static String SERVICE_LOCAL_ADDRESS = "someaddress.local";
   public final static String TEST_ADDRESS = "testaddress";
 
-  MessageConsumer<JsonObject> consumer;
-  TestService service;
-  TestService proxy;
+  MessageConsumer<JsonObject> consumer, localConsumer;
+  TestService service, localService;
+  TestService proxy, localServiceProxy;
 
   @Override
   public void setUp() throws Exception {
     super.setUp();
     service = TestService.create(vertx);
+    localService = TestService.create(vertx);
     consumer = ProxyHelper.registerService(TestService.class, vertx, service, SERVICE_ADDRESS);
+    localConsumer = ProxyHelper.registerLocalService(TestService.class, vertx, localService, SERVICE_LOCAL_ADDRESS);
     proxy = TestService.createProxy(vertx, SERVICE_ADDRESS);
+    localServiceProxy = TestService.createProxy(vertx, SERVICE_LOCAL_ADDRESS);
     vertx.eventBus().<String>consumer(TEST_ADDRESS).handler(msg -> {
       assertEquals("ok", msg.body());
       testComplete();
@@ -896,6 +900,12 @@ public class ServiceProxyTest extends VertxTestBase {
       assertEquals(ReplyFailure.TIMEOUT, re.failureType());
       testComplete();
     }));
+    await();
+  }
+
+  @Test
+  public void testLocalServiceFromLocalSender() {
+    localServiceProxy.noParams();
     await();
   }
 


### PR DESCRIPTION
To be able to register a local, non-clustered handler with the handler proxy. Changed the base abstract ProxyHandler class, as well as the code generator template.
