### PR TITLE
update convertMap, convertList, and convertSet to match proxygen

### DIFF
--- a/src/main/resources/serviceproxy/template/handlergen.templ
+++ b/src/main/resources/serviceproxy/template/handlergen.templ
@@ -50,6 +50,7 @@ import java.util.Map;\n
 import java.util.Set;\n
 import java.util.UUID;\n
 import java.util.stream.Collectors;\n
+import java.util.function.Function;\n
 import io.vertx.serviceproxy.ProxyHelper;\n
 import io.vertx.serviceproxy.ProxyHandler;\n
 @foreach{importedType:importedTypes}
@@ -308,15 +309,47 @@ createHandler(msg)
   }\n
 \n
   private <T> Map<String, T> convertMap(Map map) {\n
-    return (Map<String, T>)map;\n
+    if (map.isEmpty()) { \n
+      return (Map<String, T>) map; \n
+    } \n
+     \n
+    Object elem = map.values().stream().findFirst().get(); \n
+    if (!(elem instanceof Map) && !(elem instanceof List)) { \n
+      return (Map<String, T>) map; \n
+    } else { \n
+      Function<Object, T> converter; \n
+      if (elem instanceof List) { \n
+        converter = object -> (T) new JsonArray((List) object); \n
+      } else { \n
+        converter = object -> (T) new JsonObject((Map) object); \n
+      } \n
+      return ((Map<String, T>) map).entrySet() \n
+       .stream() \n
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); \n
+    } \n
   }\n
-\n
+
   private <T> List<T> convertList(List list) {\n
-    return (List<T>)list;\n
+    if (list.isEmpty()) { \n
+          return (List<T>) list; \n
+        } \n
+     \n
+    Object elem = list.get(0); \n
+    if (!(elem instanceof Map) && !(elem instanceof List)) { \n
+      return (List<T>) list; \n
+    } else { \n
+      Function<Object, T> converter; \n
+      if (elem instanceof List) { \n
+        converter = object -> (T) new JsonArray((List) object); \n
+      } else { \n
+        converter = object -> (T) new JsonObject((Map) object); \n
+      } \n
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); \n
+    } \n
   }\n
-\n
+
   private <T> Set<T> convertSet(List list) {\n
-    return new HashSet<T>((List<T>)list);\n
+    return new HashSet<T>(convertList(list));\n
   }\n
 
 }

--- a/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxProxyHandler.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
@@ -241,14 +242,44 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
-
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
-
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxProxyHandler.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
 
@@ -182,14 +183,44 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
-
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
-
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
 import io.vertx.core.json.JsonObject;
@@ -204,14 +205,44 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
-
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
-
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
 import io.vertx.core.AsyncResult;
@@ -190,14 +191,44 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
-
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
-
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
 import io.vertx.serviceproxy.testmodel.TestService;
@@ -526,14 +527,44 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
   }
 
   private <T> Map<String, T> convertMap(Map map) {
-    return (Map<String, T>)map;
+    if (map.isEmpty()) { 
+      return (Map<String, T>) map; 
+    } 
+     
+    Object elem = map.values().stream().findFirst().get(); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (Map<String, T>) map; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return ((Map<String, T>) map).entrySet() 
+       .stream() 
+       .collect(Collectors.toMap(Map.Entry::getKey, converter::apply)); 
+    } 
   }
-
   private <T> List<T> convertList(List list) {
-    return (List<T>)list;
+    if (list.isEmpty()) { 
+          return (List<T>) list; 
+        } 
+     
+    Object elem = list.get(0); 
+    if (!(elem instanceof Map) && !(elem instanceof List)) { 
+      return (List<T>) list; 
+    } else { 
+      Function<Object, T> converter; 
+      if (elem instanceof List) { 
+        converter = object -> (T) new JsonArray((List) object); 
+      } else { 
+        converter = object -> (T) new JsonObject((Map) object); 
+      } 
+      return (List<T>) list.stream().map(converter).collect(Collectors.toList()); 
+    } 
   }
-
   private <T> Set<T> convertSet(List list) {
-    return new HashSet<T>((List<T>)list);
+    return new HashSet<T>(convertList(list));
   }
 }

--- a/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
@@ -70,12 +70,21 @@ public class ServiceProvider implements Service {
 
   @Override
   public Service methodWithListOfDataObject(List<TestDataObject> list, Handler<AsyncResult<List<TestDataObject>>> result) {
+    // access the data
+    if(list != null && list.size() > 0) {
+      TestDataObject data = list.get(0);
+    }
     result.handle(Future.succeededFuture(list));
     return this;
   }
 
   @Override
   public Service methodWithListOfJsonObject(List<JsonObject> list, Handler<AsyncResult<List<JsonObject>>> result) {
+    // access the data
+    if(list != null && list.size() > 0) {
+      JsonObject data = list.get(0);
+    }
+
     result.handle(Future.succeededFuture(list));
     return this;
   }

--- a/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
@@ -9,6 +9,7 @@ import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.serviceproxy.testmodel.SomeVertxEnum;
 import io.vertx.serviceproxy.testmodel.TestDataObject;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -70,22 +71,35 @@ public class ServiceProvider implements Service {
 
   @Override
   public Service methodWithListOfDataObject(List<TestDataObject> list, Handler<AsyncResult<List<TestDataObject>>> result) {
-    // access the data
+    // create new list with same objects passed in to simulate a service call doing something with the data
+    List<TestDataObject> newList = new ArrayList<>();
+
+    // access the data and add to new list
     if(list != null && list.size() > 0) {
-      TestDataObject data = list.get(0);
+      for (int i = 0; i < list.size(); i++) {
+        TestDataObject data = list.get(i);
+        newList.add(data);
+      }
     }
-    result.handle(Future.succeededFuture(list));
+
+    result.handle(Future.succeededFuture(newList));
     return this;
   }
 
   @Override
   public Service methodWithListOfJsonObject(List<JsonObject> list, Handler<AsyncResult<List<JsonObject>>> result) {
-    // access the data
+    // create new list with same objects passed in to simulate a service call doing something with the data
+    List<JsonObject> newList = new ArrayList<>();
+
+    // access the data and add to new list
     if(list != null && list.size() > 0) {
-      JsonObject data = list.get(0);
+      for (int i = 0; i < list.size(); i++) {
+        JsonObject data = list.get(i);
+        newList.add(data);
+      }
     }
 
-    result.handle(Future.succeededFuture(list));
+    result.handle(Future.succeededFuture(newList));
     return this;
   }
 


### PR DESCRIPTION
These methods should probably have been updated at the same time as their proxygen counterparts with [this commit](https://github.com/vert-x3/vertx-service-proxy/commit/317a24229fc9465d4cb46937501a2636101330cd)

This will fix a specific problem we were having in production (intermittently and only when clustered) where a `List<JsonObject>` sent from one node to another ended up as `List<LinkedHashMap>`. When trying to access an item in this list via `get(0)` this exception would be thrown due to a failed implicit conversion: `java.util.LinkedHashMap cannot be cast to io.vertx.core.json.JsonObject`.

The previous `convertList` did not account for the `JsonObject` getting converted to a `LinkedHashMap` over the wire when clustered.
