### PR TITLE
Improve Error handling in service proxies.

### DIFF
--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -368,6 +368,106 @@ private static final BAD_SHOE_SIZE_ERROR = 42;
 }
 ----
 
+Then the client side can check for the Service exception, and the specific error code inside:
+[source,java]
+----
+public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
+  service.createConnection("8", result -> {
+    if (result.succeeded()) {
+      // Do success stuff.
+    } else {
+      if (result.cause() instanceof ServiceException) {
+        ServiceException exc = (ServiceException) result.cause();
+        if (exc.failureCode() == SomeDatabaseServiceImpl.BAD_SHOE_SIZE_ERROR) {
+          handler.handle(Future.failedFuture(
+            new InvalidInputError("You provided a bad shoe size")));
+        }
+      } else {
+        // Must be a system error (e.g. No service registered for the proxy)
+        handler.handle(Future.failedFuture(
+          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
+        ));
+      }
+    }
+  }
+}
+----
+
+If necessary, Service implementations may als o return a sub-class of ServiceException,
+as long as a MessageCodec is created and registered for it with EventBus instance on both
+the proxy and service sides. For example:
+
+[source,java]
+----
+class ShoeSizeException extends ServiceException {
+  public static final BAD_SHOE_SIZE_ERROR = 42;
+
+  private final String shoeSize;
+
+  public ShoeSizeException(String shoeSize) {
+    super(BAD_SHOE_SIZE_ERROR, "In invalid shoe size was received: " + shoeSize);
+    this.shoeSize = shoeSize;
+  }
+
+  public String getShoeSize() {
+    return extra;
+  }
+
+  public static <T> AsyncResult<T> fail(int failureCode, String message, String shoeSize) {
+    return Future.failedFuture(new MyServiceException(failureCode, message, shoeSize));
+  }
+}
+----
+
+Then, as long as a MessageCodec is regstered, the Service implementation can return the custom
+exception:
+[source,java]
+----
+public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+  public SomeDataBaseServiceImpl(Vertx vertx) {
+    // Register on the service side. If using a local event bus, this is all
+    // that's required, since the proxy side will share the same Vertx instance.
+    vertx.eventBus().registerDefaultCodec(ShoeSizeException.class,
+      new ShoeSizeExceptionMessageCodec());
+  }
+
+  // Create a connection
+  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+    if (!shoeSize.equals("9")) {
+      resultHandler.handle(ShoeSizeException.fail(shoeSize));
+    } else {
+      // Create the connection here
+      resultHandler.Handle(Future.succeededFuture(myDbConnection));
+    }
+  }
+}
+---
+Finally, the client can now check for the custom exception, too:
+
+[source,java]
+----
+public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
+  // If this code is running on a different node in the cluster, the
+  // ShoeSizeExceptionMessageCodec will need to be registered here, too.
+  service.createConnection("8", result -> {
+    if (result.succeeded()) {
+      // Do success stuff.
+    } else {
+      if (result.cause() instanceof ShoeSizeException) {
+        ShoeSizeException exc = (ShoeSizeException) result.cause();
+        handler.handle(Future.failedFuture(
+          new InvalidInputError("You provided a bad shoe size: " + exc.getShoeSize())));
+      } else {
+        // Must be a system error (e.g. No service registered for the proxy)
+        handler.handle(Future.failedFuture(
+          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
+        ));
+      }
+    }
+  }
+}
+----
+
 ### Overloaded methods
 
 There must be no overloaded service methods. (_i.e._ more than one with the same name, regardless the signature).

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -292,6 +292,154 @@ public interface SomeDatabaseService {
 }
 ----
 
+## Error Handling
+
+Service methods may return errors to the client by passing a failed `Future` containing a `link:../../apidocs/io/vertx/serviceproxy/ServiceException.html[ServiceException]`
+instance to the method's `Handler`. A `ServiceException` contains an `int` failure code, a message, and an optional
+`JsonObject` containing any extra information deemed important to return to the caller. For convenience, the
+`link:../../apidocs/io/vertx/serviceproxy/ServiceException.html#fail-int-java.lang.String-[ServiceException.fail]` factory method can be used to create an instance of
+`ServiceException` already wrapped in a failed `Future`. For example:
+
+[source,java]
+----
+public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+private static final BAD_SHOE_SIZE = 42;
+private static final CONNECTION_FAILED = 43;
+
+  // Create a connection
+  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+    if (!shoeSize.equals("9")) {
+      resultHandler.handle(ServiceException.fail(BAD_SHOE_SIZE, "The shoe size must be 9!",
+        new JsonObject().put("shoeSize", shoeSize));
+     } else {
+        doDbConnection(result -> {
+          if (result.succeeded()) {
+            resultHandler.handle(Future.succeededFuture(result.result()));
+          } else {
+            resultHandler.handle(ServiceException.fail(CONNECTION_FAILED, result.cause().getMessage()));
+          }
+        });
+     }
+  }
+}
+----
+
+The client side can then check if the `Throwable` it receives from a failed `AsyncResult` is a `ServiceException`,
+and if so, check the specific error code inside. It can use this information to differentiate business logic
+errors from system errors (like the service not being registered with the Event Bus), and to determine exactly
+which business logic error occurred.
+
+[source,java]
+----
+public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
+  SomeDatabaseService service = SomeDatabaseService.createProxy(vertx, SERVICE_ADDRESS);
+  service.createConnection("8", result -> {
+    if (result.succeeded()) {
+      // Do success stuff.
+    } else {
+      if (result.cause() instanceof ServiceException) {
+        ServiceException exc = (ServiceException) result.cause();
+        if (exc.failureCode() == SomeDatabaseServiceImpl.BAD_SHOE_SIZE) {
+          handler.handle(Future.failedFuture(
+            new InvalidInputError("You provided a bad shoe size: " +
+              exc.getDebugInfo().getString("shoeSize"))
+          ));
+        } else if (exc.failureCode() == SomeDatabaseServiceImpl.CONNECTION) {
+          handler.handle(Future.failedFuture(
+            new ConnectionError("Failed to connect to the DB")));
+        }
+      } else {
+        // Must be a system error (e.g. No service registered for the proxy)
+        handler.handle(Future.failedFuture(
+          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
+        ));
+      }
+    }
+  }
+}
+----
+
+If desired, service implementations may also return a sub-class of `ServiceException`, as long as a
+default `MessageCodec` is registered for it . For example, given the following `ServiceException` sub-class:
+
+[source,java]
+----
+class ShoeSizeException extends ServiceException {
+  public static final BAD_SHOE_SIZE_ERROR = 42;
+
+  private final String shoeSize;
+
+  public ShoeSizeException(String shoeSize) {
+    super(BAD_SHOE_SIZE_ERROR, "In invalid shoe size was received: " + shoeSize);
+    this.shoeSize = shoeSize;
+  }
+
+  public String getShoeSize() {
+    return extra;
+  }
+
+  public static <T> AsyncResult<T> fail(int failureCode, String message, String shoeSize) {
+    return Future.failedFuture(new MyServiceException(failureCode, message, shoeSize));
+  }
+}
+----
+
+As long as a default `MessageCodec` is registered, the Service implementation can return the custom
+exception directly to the caller:
+
+[source,java]
+----
+public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+  public SomeDataBaseServiceImpl(Vertx vertx) {
+    // Register on the service side. If using a local event bus, this is all
+    // that's required, since the proxy side will share the same Vertx instance.
+  SomeDatabaseService service = SomeDatabaseService.createProxy(vertx, SERVICE_ADDRESS);
+    vertx.eventBus().registerDefaultCodec(ShoeSizeException.class,
+      new ShoeSizeExceptionMessageCodec());
+  }
+
+  // Create a connection
+  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+    if (!shoeSize.equals("9")) {
+      resultHandler.handle(ShoeSizeException.fail(shoeSize));
+    } else {
+      // Create the connection here
+      resultHandler.Handle(Future.succeededFuture(myDbConnection));
+    }
+  }
+}
+----
+Finally, the client can now check for the custom exception:
+
+[source,java]
+----
+public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
+  // If this code is running on a different node in the cluster, the
+  // ShoeSizeExceptionMessageCodec will need to be registered with the
+  // Vertx instance on this node, too.
+  SomeDatabaseService service = SomeDatabaseService.createProxy(vertx, SERVICE_ADDRESS);
+  service.createConnection("8", result -> {
+    if (result.succeeded()) {
+      // Do success stuff.
+    } else {
+      if (result.cause() instanceof ShoeSizeException) {
+        ShoeSizeException exc = (ShoeSizeException) result.cause();
+        handler.handle(Future.failedFuture(
+          new InvalidInputError("You provided a bad shoe size: " + exc.getShoeSize())));
+      } else {
+        // Must be a system error (e.g. No service registered for the proxy)
+        handler.handle(Future.failedFuture(
+          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
+        ));
+      }
+    }
+  }
+}
+----
+
+Note that if you're clustering `Vertx` instances, you'll need to register the custom Exception's `MessageCodec`
+with each `Vertx` instance in the cluster.
+
 ## Restrictions for service interface
 
 There are restrictions on the types and return values that can be used in a service method so that these are easy to
@@ -344,129 +492,6 @@ If an asynchronous result is required a last parameter of type `Handler<AsyncRes
 * Any _Enum_ type
 * Any class annotated with `@DataObject`
 * Another proxy
-
-### Error Handling
-
-Service methods may return errors to the client by passing a failed `Future` containing a `link:../../apidocs/io/vertx/serviceproxy/ServiceException.html[ServiceException]`
-instance to the method's `Handler`. The `link:../../apidocs/io/vertx/serviceproxy/ServiceException.html#fail-int-java.lang.String-[ServiceException.fail]` factory method can be used to create an instance of
-`ServiceException` already wrapped in a failed `Future`. For example:
-
-[source,java]
-----
-public class SomeDatabaseServiceImpl implements SomeDatabaseService {
-private static final BAD_SHOE_SIZE_ERROR = 42;
-
-  // Create a connection
-  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
-    if (!shoeSize.equals("9")) {
-      resultHandler.handle(ServiceException.fail(BAD_SHOE_SIZE_ERROR, "The shoe size must be 9!"));
-     } else {
-       // Create the connection here
-       resultHandler.Handle(Future.succeededFuture(myDbConnection));
-     }
-  }
-}
-----
-
-Then the client side can check for the Service exception, and the specific error code inside:
-[source,java]
-----
-public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
-  service.createConnection("8", result -> {
-    if (result.succeeded()) {
-      // Do success stuff.
-    } else {
-      if (result.cause() instanceof ServiceException) {
-        ServiceException exc = (ServiceException) result.cause();
-        if (exc.failureCode() == SomeDatabaseServiceImpl.BAD_SHOE_SIZE_ERROR) {
-          handler.handle(Future.failedFuture(
-            new InvalidInputError("You provided a bad shoe size")));
-        }
-      } else {
-        // Must be a system error (e.g. No service registered for the proxy)
-        handler.handle(Future.failedFuture(
-          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
-        ));
-      }
-    }
-  }
-}
-----
-
-If necessary, Service implementations may als o return a sub-class of ServiceException,
-as long as a MessageCodec is created and registered for it with EventBus instance on both
-the proxy and service sides. For example:
-
-[source,java]
-----
-class ShoeSizeException extends ServiceException {
-  public static final BAD_SHOE_SIZE_ERROR = 42;
-
-  private final String shoeSize;
-
-  public ShoeSizeException(String shoeSize) {
-    super(BAD_SHOE_SIZE_ERROR, "In invalid shoe size was received: " + shoeSize);
-    this.shoeSize = shoeSize;
-  }
-
-  public String getShoeSize() {
-    return extra;
-  }
-
-  public static <T> AsyncResult<T> fail(int failureCode, String message, String shoeSize) {
-    return Future.failedFuture(new MyServiceException(failureCode, message, shoeSize));
-  }
-}
-----
-
-Then, as long as a MessageCodec is regstered, the Service implementation can return the custom
-exception:
-[source,java]
-----
-public class SomeDatabaseServiceImpl implements SomeDatabaseService {
-  public SomeDataBaseServiceImpl(Vertx vertx) {
-    // Register on the service side. If using a local event bus, this is all
-    // that's required, since the proxy side will share the same Vertx instance.
-    vertx.eventBus().registerDefaultCodec(ShoeSizeException.class,
-      new ShoeSizeExceptionMessageCodec());
-  }
-
-  // Create a connection
-  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
-    if (!shoeSize.equals("9")) {
-      resultHandler.handle(ShoeSizeException.fail(shoeSize));
-    } else {
-      // Create the connection here
-      resultHandler.Handle(Future.succeededFuture(myDbConnection));
-    }
-  }
-}
----
-Finally, the client can now check for the custom exception, too:
-
-[source,java]
-----
-public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
-  // If this code is running on a different node in the cluster, the
-  // ShoeSizeExceptionMessageCodec will need to be registered here, too.
-  service.createConnection("8", result -> {
-    if (result.succeeded()) {
-      // Do success stuff.
-    } else {
-      if (result.cause() instanceof ShoeSizeException) {
-        ShoeSizeException exc = (ShoeSizeException) result.cause();
-        handler.handle(Future.failedFuture(
-          new InvalidInputError("You provided a bad shoe size: " + exc.getShoeSize())));
-      } else {
-        // Must be a system error (e.g. No service registered for the proxy)
-        handler.handle(Future.failedFuture(
-          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
-        ));
-      }
-    }
-  }
-}
-----
 
 ### Overloaded methods
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -345,6 +345,29 @@ If an asynchronous result is required a last parameter of type `Handler<AsyncRes
 * Any class annotated with `@DataObject`
 * Another proxy
 
+### Error Handling
+
+Service methods may return errors to the client by passing a failed `Future` containing a `link:../../apidocs/io/vertx/serviceproxy/ServiceException.html[ServiceException]`
+instance to the method's `Handler`. The `link:../../apidocs/io/vertx/serviceproxy/ServiceException.html#fail-int-java.lang.String-[ServiceException.fail]` factory method can be used to create an instance of
+`ServiceException` already wrapped in a failed `Future`. For example:
+
+[source,java]
+----
+public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+private static final BAD_SHOE_SIZE_ERROR = 42;
+
+  // Create a connection
+  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+    if (!shoeSize.equals("9")) {
+      resultHandler.handle(ServiceException.fail(BAD_SHOE_SIZE_ERROR, "The shoe size must be 9!"));
+     } else {
+       // Create the connection here
+       resultHandler.Handle(Future.succeededFuture(myDbConnection));
+     }
+  }
+}
+----
+
 ### Overloaded methods
 
 There must be no overloaded service methods. (_i.e._ more than one with the same name, regardless the signature).

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -368,6 +368,106 @@ private static final BAD_SHOE_SIZE_ERROR = 42;
 }
 ----
 
+Then the client side can check for the Service exception, and the specific error code inside:
+[source,java]
+----
+public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
+  service.createConnection("8", result -> {
+    if (result.succeeded()) {
+      // Do success stuff.
+    } else {
+      if (result.cause() instanceof ServiceException) {
+        ServiceException exc = (ServiceException) result.cause();
+        if (exc.failureCode() == SomeDatabaseServiceImpl.BAD_SHOE_SIZE_ERROR) {
+          handler.handle(Future.failedFuture(
+            new InvalidInputError("You provided a bad shoe size")));
+        }
+      } else {
+        // Must be a system error (e.g. No service registered for the proxy)
+        handler.handle(Future.failedFuture(
+          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
+        ));
+      }
+    }
+  }
+}
+----
+
+If necessary, Service implementations may als o return a sub-class of ServiceException,
+as long as a MessageCodec is created and registered for it with EventBus instance on both
+the proxy and service sides. For example:
+
+[source,java]
+----
+class ShoeSizeException extends ServiceException {
+  public static final BAD_SHOE_SIZE_ERROR = 42;
+
+  private final String shoeSize;
+
+  public ShoeSizeException(String shoeSize) {
+    super(BAD_SHOE_SIZE_ERROR, "In invalid shoe size was received: " + shoeSize);
+    this.shoeSize = shoeSize;
+  }
+
+  public String getShoeSize() {
+    return extra;
+  }
+
+  public static <T> AsyncResult<T> fail(int failureCode, String message, String shoeSize) {
+    return Future.failedFuture(new MyServiceException(failureCode, message, shoeSize));
+  }
+}
+----
+
+Then, as long as a MessageCodec is regstered, the Service implementation can return the custom
+exception:
+[source,java]
+----
+public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+  public SomeDataBaseServiceImpl(Vertx vertx) {
+    // Register on the service side. If using a local event bus, this is all
+    // that's required, since the proxy side will share the same Vertx instance.
+    vertx.eventBus().registerDefaultCodec(ShoeSizeException.class,
+      new ShoeSizeExceptionMessageCodec());
+  }
+
+  // Create a connection
+  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+    if (!shoeSize.equals("9")) {
+      resultHandler.handle(ShoeSizeException.fail(shoeSize));
+    } else {
+      // Create the connection here
+      resultHandler.Handle(Future.succeededFuture(myDbConnection));
+    }
+  }
+}
+---
+Finally, the client can now check for the custom exception, too:
+
+[source,java]
+----
+public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
+  // If this code is running on a different node in the cluster, the
+  // ShoeSizeExceptionMessageCodec will need to be registered here, too.
+  service.createConnection("8", result -> {
+    if (result.succeeded()) {
+      // Do success stuff.
+    } else {
+      if (result.cause() instanceof ShoeSizeException) {
+        ShoeSizeException exc = (ShoeSizeException) result.cause();
+        handler.handle(Future.failedFuture(
+          new InvalidInputError("You provided a bad shoe size: " + exc.getShoeSize())));
+      } else {
+        // Must be a system error (e.g. No service registered for the proxy)
+        handler.handle(Future.failedFuture(
+          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
+        ));
+      }
+    }
+  }
+}
+----
+
 ### Overloaded methods
 
 There must be no overloaded service methods. (_i.e._ more than one with the same name, regardless the signature).

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -345,6 +345,29 @@ If an asynchronous result is required a last parameter of type `Handler<AsyncRes
 * Any class annotated with `@DataObject`
 * Another proxy
 
+### Error Handling
+
+Service methods may return errors to the client by passing a failed `Future` containing a `ServiceException`
+instance to the method's `Handler`. The `ServiceException.fail` factory method can be used to create an instance of
+`ServiceException` already wrapped in a failed `Future`. For example:
+
+[source,java]
+----
+public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+private static final BAD_SHOE_SIZE_ERROR = 42;
+
+  // Create a connection
+  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+    if (!shoeSize.equals("9")) {
+      resultHandler.handle(ServiceException.fail(BAD_SHOE_SIZE_ERROR, "The shoe size must be 9!"));
+     } else {
+       // Create the connection here
+       resultHandler.Handle(Future.succeededFuture(myDbConnection));
+     }
+  }
+}
+----
+
 ### Overloaded methods
 
 There must be no overloaded service methods. (_i.e._ more than one with the same name, regardless the signature).

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -292,6 +292,154 @@ public interface SomeDatabaseService {
 }
 ----
 
+## Error Handling
+
+Service methods may return errors to the client by passing a failed `Future` containing a `ServiceException`
+instance to the method's `Handler`. A `ServiceException` contains an `int` failure code, a message, and an optional
+`JsonObject` containing any extra information deemed important to return to the caller. For convenience, the
+`ServiceException.fail` factory method can be used to create an instance of
+`ServiceException` already wrapped in a failed `Future`. For example:
+
+[source,java]
+----
+public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+private static final BAD_SHOE_SIZE = 42;
+private static final CONNECTION_FAILED = 43;
+
+  // Create a connection
+  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+    if (!shoeSize.equals("9")) {
+      resultHandler.handle(ServiceException.fail(BAD_SHOE_SIZE, "The shoe size must be 9!",
+        new JsonObject().put("shoeSize", shoeSize));
+     } else {
+        doDbConnection(result -> {
+          if (result.succeeded()) {
+            resultHandler.handle(Future.succeededFuture(result.result()));
+          } else {
+            resultHandler.handle(ServiceException.fail(CONNECTION_FAILED, result.cause().getMessage()));
+          }
+        });
+     }
+  }
+}
+----
+
+The client side can then check if the `Throwable` it receives from a failed `AsyncResult` is a `ServiceException`,
+and if so, check the specific error code inside. It can use this information to differentiate business logic
+errors from system errors (like the service not being registered with the Event Bus), and to determine exactly
+which business logic error occurred.
+
+[source,java]
+----
+public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
+  SomeDatabaseService service = SomeDatabaseService.createProxy(vertx, SERVICE_ADDRESS);
+  service.createConnection("8", result -> {
+    if (result.succeeded()) {
+      // Do success stuff.
+    } else {
+      if (result.cause() instanceof ServiceException) {
+        ServiceException exc = (ServiceException) result.cause();
+        if (exc.failureCode() == SomeDatabaseServiceImpl.BAD_SHOE_SIZE) {
+          handler.handle(Future.failedFuture(
+            new InvalidInputError("You provided a bad shoe size: " +
+              exc.getDebugInfo().getString("shoeSize"))
+          ));
+        } else if (exc.failureCode() == SomeDatabaseServiceImpl.CONNECTION) {
+          handler.handle(Future.failedFuture(
+            new ConnectionError("Failed to connect to the DB")));
+        }
+      } else {
+        // Must be a system error (e.g. No service registered for the proxy)
+        handler.handle(Future.failedFuture(
+          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
+        ));
+      }
+    }
+  }
+}
+----
+
+If desired, service implementations may also return a sub-class of `ServiceException`, as long as a
+default `MessageCodec` is registered for it . For example, given the following `ServiceException` sub-class:
+
+[source,java]
+----
+class ShoeSizeException extends ServiceException {
+  public static final BAD_SHOE_SIZE_ERROR = 42;
+
+  private final String shoeSize;
+
+  public ShoeSizeException(String shoeSize) {
+    super(BAD_SHOE_SIZE_ERROR, "In invalid shoe size was received: " + shoeSize);
+    this.shoeSize = shoeSize;
+  }
+
+  public String getShoeSize() {
+    return extra;
+  }
+
+  public static <T> AsyncResult<T> fail(int failureCode, String message, String shoeSize) {
+    return Future.failedFuture(new MyServiceException(failureCode, message, shoeSize));
+  }
+}
+----
+
+As long as a default `MessageCodec` is registered, the Service implementation can return the custom
+exception directly to the caller:
+
+[source,java]
+----
+public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+  public SomeDataBaseServiceImpl(Vertx vertx) {
+    // Register on the service side. If using a local event bus, this is all
+    // that's required, since the proxy side will share the same Vertx instance.
+  SomeDatabaseService service = SomeDatabaseService.createProxy(vertx, SERVICE_ADDRESS);
+    vertx.eventBus().registerDefaultCodec(ShoeSizeException.class,
+      new ShoeSizeExceptionMessageCodec());
+  }
+
+  // Create a connection
+  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+    if (!shoeSize.equals("9")) {
+      resultHandler.handle(ShoeSizeException.fail(shoeSize));
+    } else {
+      // Create the connection here
+      resultHandler.Handle(Future.succeededFuture(myDbConnection));
+    }
+  }
+}
+----
+Finally, the client can now check for the custom exception:
+
+[source,java]
+----
+public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
+  // If this code is running on a different node in the cluster, the
+  // ShoeSizeExceptionMessageCodec will need to be registered with the
+  // Vertx instance on this node, too.
+  SomeDatabaseService service = SomeDatabaseService.createProxy(vertx, SERVICE_ADDRESS);
+  service.createConnection("8", result -> {
+    if (result.succeeded()) {
+      // Do success stuff.
+    } else {
+      if (result.cause() instanceof ShoeSizeException) {
+        ShoeSizeException exc = (ShoeSizeException) result.cause();
+        handler.handle(Future.failedFuture(
+          new InvalidInputError("You provided a bad shoe size: " + exc.getShoeSize())));
+      } else {
+        // Must be a system error (e.g. No service registered for the proxy)
+        handler.handle(Future.failedFuture(
+          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
+        ));
+      }
+    }
+  }
+}
+----
+
+Note that if you're clustering `Vertx` instances, you'll need to register the custom Exception's `MessageCodec`
+with each `Vertx` instance in the cluster.
+
 ## Restrictions for service interface
 
 There are restrictions on the types and return values that can be used in a service method so that these are easy to
@@ -344,129 +492,6 @@ If an asynchronous result is required a last parameter of type `Handler<AsyncRes
 * Any _Enum_ type
 * Any class annotated with `@DataObject`
 * Another proxy
-
-### Error Handling
-
-Service methods may return errors to the client by passing a failed `Future` containing a `ServiceException`
-instance to the method's `Handler`. The `ServiceException.fail` factory method can be used to create an instance of
-`ServiceException` already wrapped in a failed `Future`. For example:
-
-[source,java]
-----
-public class SomeDatabaseServiceImpl implements SomeDatabaseService {
-private static final BAD_SHOE_SIZE_ERROR = 42;
-
-  // Create a connection
-  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
-    if (!shoeSize.equals("9")) {
-      resultHandler.handle(ServiceException.fail(BAD_SHOE_SIZE_ERROR, "The shoe size must be 9!"));
-     } else {
-       // Create the connection here
-       resultHandler.Handle(Future.succeededFuture(myDbConnection));
-     }
-  }
-}
-----
-
-Then the client side can check for the Service exception, and the specific error code inside:
-[source,java]
-----
-public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
-  service.createConnection("8", result -> {
-    if (result.succeeded()) {
-      // Do success stuff.
-    } else {
-      if (result.cause() instanceof ServiceException) {
-        ServiceException exc = (ServiceException) result.cause();
-        if (exc.failureCode() == SomeDatabaseServiceImpl.BAD_SHOE_SIZE_ERROR) {
-          handler.handle(Future.failedFuture(
-            new InvalidInputError("You provided a bad shoe size")));
-        }
-      } else {
-        // Must be a system error (e.g. No service registered for the proxy)
-        handler.handle(Future.failedFuture(
-          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
-        ));
-      }
-    }
-  }
-}
-----
-
-If necessary, Service implementations may als o return a sub-class of ServiceException,
-as long as a MessageCodec is created and registered for it with EventBus instance on both
-the proxy and service sides. For example:
-
-[source,java]
-----
-class ShoeSizeException extends ServiceException {
-  public static final BAD_SHOE_SIZE_ERROR = 42;
-
-  private final String shoeSize;
-
-  public ShoeSizeException(String shoeSize) {
-    super(BAD_SHOE_SIZE_ERROR, "In invalid shoe size was received: " + shoeSize);
-    this.shoeSize = shoeSize;
-  }
-
-  public String getShoeSize() {
-    return extra;
-  }
-
-  public static <T> AsyncResult<T> fail(int failureCode, String message, String shoeSize) {
-    return Future.failedFuture(new MyServiceException(failureCode, message, shoeSize));
-  }
-}
-----
-
-Then, as long as a MessageCodec is regstered, the Service implementation can return the custom
-exception:
-[source,java]
-----
-public class SomeDatabaseServiceImpl implements SomeDatabaseService {
-  public SomeDataBaseServiceImpl(Vertx vertx) {
-    // Register on the service side. If using a local event bus, this is all
-    // that's required, since the proxy side will share the same Vertx instance.
-    vertx.eventBus().registerDefaultCodec(ShoeSizeException.class,
-      new ShoeSizeExceptionMessageCodec());
-  }
-
-  // Create a connection
-  void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
-    if (!shoeSize.equals("9")) {
-      resultHandler.handle(ShoeSizeException.fail(shoeSize));
-    } else {
-      // Create the connection here
-      resultHandler.Handle(Future.succeededFuture(myDbConnection));
-    }
-  }
-}
----
-Finally, the client can now check for the custom exception, too:
-
-[source,java]
-----
-public void foo(String shoeSize, Handler<AsyncResult<JsonObject>> handler) {
-  // If this code is running on a different node in the cluster, the
-  // ShoeSizeExceptionMessageCodec will need to be registered here, too.
-  service.createConnection("8", result -> {
-    if (result.succeeded()) {
-      // Do success stuff.
-    } else {
-      if (result.cause() instanceof ShoeSizeException) {
-        ShoeSizeException exc = (ShoeSizeException) result.cause();
-        handler.handle(Future.failedFuture(
-          new InvalidInputError("You provided a bad shoe size: " + exc.getShoeSize())));
-      } else {
-        // Must be a system error (e.g. No service registered for the proxy)
-        handler.handle(Future.failedFuture(
-          new SystemError("An unexpected error occurred: + " result.cause().getMessage())
-        ));
-      }
-    }
-  }
-}
-----
 
 ### Overloaded methods
 

--- a/src/main/java/io/vertx/serviceproxy/ServiceException.java
+++ b/src/main/java/io/vertx/serviceproxy/ServiceException.java
@@ -4,6 +4,7 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.eventbus.ReplyFailure;
+import io.vertx.core.json.JsonObject;
 
 /**
  * An Exception to be returned from Service implementations.
@@ -12,6 +13,8 @@ import io.vertx.core.eventbus.ReplyFailure;
  */
 public class ServiceException extends ReplyException {
 
+  private final JsonObject debugInfo;
+
   /**
    * Create a ServiceException.
    *
@@ -19,19 +22,48 @@ public class ServiceException extends ReplyException {
    * @param message The failure message.
    */
   public ServiceException(int failureCode, String message) {
+    this(failureCode, message, new JsonObject());
+  }
+
+  public ServiceException(int failureCode, String message, JsonObject debugInfo) {
     super(ReplyFailure.RECIPIENT_FAILURE, failureCode, message);
+    this.debugInfo = debugInfo;
+
+  }
+
+  /**
+   * Get the Debugging information provided to this ServiceException
+   *
+   * @return The debug info.
+   */
+  public JsonObject getDebugInfo() {
+    return debugInfo;
   }
 
   /**
    * Create a failed Future containing a ServiceException.
    *
-   * @param <T> The type of the AsyncResult.
    * @param failureCode The failure code.
    * @param message The failure message.
+   * @param <T> The type of the AsyncResult.
    * @return A failed Future containing the ServiceException.
    */
   public static <T> AsyncResult<T> fail(int failureCode, String message) {
     return Future.failedFuture(new ServiceException(failureCode, message));
+  }
+
+  /**
+   *
+   * Create a failed Future containing a ServiceException.
+   *
+   * @param failureCode The failure code.
+   * @param message The failure message.
+   * @param debugInfo The debug info.
+   * @param <T> The type of the AsyncResult.
+   * @return A failed Future containing the ServiceException.
+   */
+  public static <T> AsyncResult<T> fail(int failureCode, String message, JsonObject debugInfo) {
+    return Future.failedFuture(new ServiceException(failureCode, message, debugInfo));
   }
 
 }

--- a/src/main/java/io/vertx/serviceproxy/ServiceException.java
+++ b/src/main/java/io/vertx/serviceproxy/ServiceException.java
@@ -1,0 +1,37 @@
+package io.vertx.serviceproxy;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
+
+/**
+ * An Exception to be returned from Service implementations.
+ *
+ * @author <a href="mailto:oreilldf@gmail.com">Dan O'Reilly</a>
+ */
+public class ServiceException extends ReplyException {
+
+  /**
+   * Create a ServiceException.
+   *
+   * @param failureCode The failure code.
+   * @param message The failure message.
+   */
+  public ServiceException(int failureCode, String message) {
+    super(ReplyFailure.RECIPIENT_FAILURE, failureCode, message);
+  }
+
+  /**
+   * Create a failed Future containing a ServiceException.
+   *
+   * @param <T> The type of the AsyncResult.
+   * @param failureCode The failure code.
+   * @param message The failure message.
+   * @return A failed Future containing the ServiceException.
+   */
+  public static <T> AsyncResult<T> fail(int failureCode, String message) {
+    return Future.failedFuture(new ServiceException(failureCode, message));
+  }
+
+}

--- a/src/main/java/io/vertx/serviceproxy/ServiceExceptionMessageCodec.java
+++ b/src/main/java/io/vertx/serviceproxy/ServiceExceptionMessageCodec.java
@@ -1,0 +1,60 @@
+package io.vertx.serviceproxy;
+
+import io.netty.util.CharsetUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+
+/**
+ * A MessageCodec for ServiceException
+ *
+ * @author <a href="mailto:oreilldf@gmail.com">Dan O'Reilly</a>
+ */
+public class ServiceExceptionMessageCodec implements MessageCodec<ServiceException, ServiceException> {
+
+  @Override
+  public void encodeToWire(Buffer buffer, ServiceException body) {
+    buffer.appendInt(body.failureCode());
+    if (body.getMessage() == null) {
+      buffer.appendByte((byte)0);
+    } else {
+      buffer.appendByte((byte)1);
+      byte[] encoded = body.getMessage().getBytes(CharsetUtil.UTF_8);
+      buffer.appendInt(encoded.length);
+      buffer.appendBytes(encoded);
+    }
+  }
+
+  @Override
+  public ServiceException decodeFromWire(int pos, Buffer buffer) {
+    int failureCode = buffer.getInt(pos);
+    pos += 4;
+    boolean isNull = buffer.getByte(pos) == (byte)0;
+    String message;
+    if (!isNull) {
+      pos++;
+      int strLength = buffer.getInt(pos);
+      pos += 4;
+      byte[] bytes = buffer.getBytes(pos, pos + strLength);
+      message = new String(bytes, CharsetUtil.UTF_8);
+    } else {
+      message = null;
+    }
+    return new ServiceException(failureCode, message);
+  }
+
+  @Override
+  public ServiceException transform(ServiceException exception) {
+    return exception;
+  }
+
+  @Override
+  public String name() {
+    return "ServiceException";
+  }
+
+  @Override
+  public byte systemCodecID() {
+    return -1;
+  }
+}
+

--- a/src/main/java/io/vertx/serviceproxy/package-info.java
+++ b/src/main/java/io/vertx/serviceproxy/package-info.java
@@ -325,6 +325,29 @@
  * * Any class annotated with `@DataObject`
  * * Another proxy
  *
+ * ### Error Handling
+ *
+ * Service methods may return errors to the client by passing a failed `Future` containing a {@link io.vertx.serviceproxy.ServiceException}
+ * instance to the method's `Handler`. The {@link io.vertx.serviceproxy.ServiceException#fail} factory method can be used to create an instance of
+ * `ServiceException` already wrapped in a failed `Future`. For example:
+ *
+ * [source,java]
+ * ----
+ * public class SomeDatabaseServiceImpl implements SomeDatabaseService {
+ * private static final BAD_SHOE_SIZE_ERROR = 42;
+ *
+ *   // Create a connection
+ *   void createConnection(String shoeSize, Handler<AsyncResult<MyDatabaseConnection>> resultHandler) {
+ *     if (!shoeSize.equals("9")) {
+ *       resultHandler.handle(ServiceException.fail(BAD_SHOE_SIZE_ERROR, "The shoe size must be 9!"));
+ *      } else {
+ *        // Create the connection here
+ *        resultHandler.Handle(Future.succeededFuture(myDbConnection));
+ *      }
+ *   }
+ * }
+ * ----
+ *
  * ### Overloaded methods
  *
  * There must be no overloaded service methods. (_i.e._ more than one with the same name, regardless the signature).

--- a/src/main/resources/serviceproxy/template/handlergen.templ
+++ b/src/main/resources/serviceproxy/template/handlergen.templ
@@ -52,6 +52,8 @@ import java.util.UUID;\n
 import java.util.stream.Collectors;\n
 import io.vertx.serviceproxy.ProxyHelper;\n
 import io.vertx.serviceproxy.ProxyHandler;\n
+import io.vertx.serviceproxy.ServiceException;\n
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;\n
 @foreach{importedType:importedTypes}
 	@if{!importedType.packageName.equals("java.lang")}
 		import @{importedType};\n
@@ -84,6 +86,10 @@ public class @{ifaceSimpleName}VertxProxyHandler extends ProxyHandler {\n
     this.vertx = vertx;\n
     this.service = service;\n
     this.timeoutSeconds = timeoutSeconds;\n
+    try {\n
+      this.vertx.eventBus().registerDefaultCodec(ServiceException.class,\n
+          new ServiceExceptionMessageCodec());\n
+    } catch (IllegalStateException ex) {}\n
     if (timeoutSeconds != -1 && !topLevel) {\n
       long period = timeoutSeconds * 1000 / 2;\n
       if (period > 10000) {\n
@@ -184,7 +190,11 @@ createListCharHandler(msg)
 			@else{hasResultHandler && lastParam.type.args[0].args[0].kind==CLASS_LIST && lastParam.type.args[0].args[0].args[0].kind==CLASS_DATA_OBJECT}
 res -> {\n
             if (res.failed()) {\n
-              msg.fail(-1, res.cause().getMessage());\n
+              if (res.cause() instanceof ServiceException) {\n
+                msg.reply(res.cause());\n
+              } else {\n
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+              }\n
             } else {\n
               msg.reply(new JsonArray(res.result().stream().map(@{lastParam.type.args[0].args[0].args[0].simpleName}::toJson).collect(Collectors.toList())));\n
             }\n
@@ -196,7 +206,11 @@ createSetCharHandler(msg)
 			@else{hasResultHandler && lastParam.type.args[0].args[0].kind==CLASS_SET && lastParam.type.args[0].args[0].args[0].kind==CLASS_DATA_OBJECT}
 res -> {\n
             if (res.failed()) {\n
-              msg.fail(-1, res.cause().getMessage());\n
+              if (res.cause() instanceof ServiceException) {\n
+                msg.reply(res.cause());\n
+              } else {\n
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+              }\n
             } else {\n
               msg.reply(new JsonArray(res.result().stream().map(@{lastParam.type.args[0].args[0].args[0].simpleName}::toJson).collect(Collectors.toList())));\n
             }\n
@@ -206,7 +220,11 @@ createSetHandler(msg)
 			@else{hasResultHandler && lastParam.type.args[0].args[0].kind==CLASS_DATA_OBJECT}
 res -> {\n
             if (res.failed()) {\n
-              msg.fail(-1, res.cause().getMessage());\n
+              if (res.cause() instanceof ServiceException) {\n
+                msg.reply(res.cause());\n
+              } else {\n
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+              }\n
             } else {\n
               msg.reply(res.result() == null ? null : res.result().toJson());\n
             }\n
@@ -214,7 +232,11 @@ res -> {\n
 			@else{hasResultHandler && lastParam.type.args[0].args[0].kind==CLASS_API && lastParam.type.args[0].args[0].proxyGen}
 res -> {\n
             if (res.failed()) {\n
-              msg.fail(-1, res.cause().getMessage());\n
+                if (res.cause() instanceof ServiceException) {\n
+                  msg.reply(res.cause());\n
+                } else {\n
+                  msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+                }\n
             } else {\n
               String proxyAddress = UUID.randomUUID().toString();\n
               ProxyHelper.registerService(@{lastParam.type.args[0].args[0].simpleName}.class, vertx, res.result(), proxyAddress, false, timeoutSeconds);\n
@@ -239,7 +261,7 @@ createHandler(msg)
       }\n
 
     } catch (Throwable t) {\n
-      msg.fail(-1, t.getMessage());\n
+      msg.reply(new ServiceException(500, t.getMessage()));\n
       throw t;\n
     }\n
 
@@ -248,13 +270,17 @@ createHandler(msg)
   private <T> Handler<AsyncResult<T>> createHandler(Message msg) {\n
     return res -> {\n
       if (res.failed()) {\n
-        msg.fail(-1, res.cause().getMessage());\n
+        if (res.cause() instanceof ServiceException) {\n
+          msg.reply(res.cause());\n
+        } else {\n
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+        }\n
       } else {\n
-        if (res.result() != null  && res.result().getClass().isEnum()) {
-          msg.reply(((Enum) res.result()).name());
-        } else {
-          msg.reply(res.result());
-        }
+        if (res.result() != null  && res.result().getClass().isEnum()) {\n
+          msg.reply(((Enum) res.result()).name());\n
+        } else {\n
+          msg.reply(res.result());\n
+        }\n
       }\n
     };\n
   }\n
@@ -262,7 +288,11 @@ createHandler(msg)
   private <T> Handler<AsyncResult<List<T>>> createListHandler(Message msg) {\n
     return res -> {\n
       if (res.failed()) {\n
-        msg.fail(-1, res.cause().getMessage());\n
+        if (res.cause() instanceof ServiceException) {\n
+          msg.reply(res.cause());\n
+        } else {\n
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+        }\n
       } else {\n
         msg.reply(new JsonArray(res.result()));\n
       }\n
@@ -272,7 +302,11 @@ createHandler(msg)
   private <T> Handler<AsyncResult<Set<T>>> createSetHandler(Message msg) {\n
     return res -> {\n
       if (res.failed()) {\n
-        msg.fail(-1, res.cause().getMessage());\n
+        if (res.cause() instanceof ServiceException) {\n
+          msg.reply(res.cause());\n
+        } else {\n
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+        }\n
       } else {\n
         msg.reply(new JsonArray(new ArrayList<>(res.result())));\n
       }\n
@@ -282,7 +316,11 @@ createHandler(msg)
   private Handler<AsyncResult<List<Character>>> createListCharHandler(Message msg) {\n
     return res -> {\n
       if (res.failed()) {\n
-        msg.fail(-1, res.cause().getMessage());\n
+        if (res.cause() instanceof ServiceException) {\n
+          msg.reply(res.cause());\n
+        } else {\n
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+        }\n
       } else {\n
         JsonArray arr = new JsonArray();\n
         for (Character chr: res.result()) {\n
@@ -296,7 +334,11 @@ createHandler(msg)
   private Handler<AsyncResult<Set<Character>>> createSetCharHandler(Message msg) {\n
     return res -> {\n
       if (res.failed()) {\n
-        msg.fail(-1, res.cause().getMessage());\n
+        if (res.cause() instanceof ServiceException) {\n
+          msg.reply(res.cause());\n
+        } else {\n
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));\n
+        }\n
       } else {\n
         JsonArray arr = new JsonArray();\n
         for (Character chr: res.result()) {\n

--- a/src/main/resources/serviceproxy/template/proxygen.templ
+++ b/src/main/resources/serviceproxy/template/proxygen.templ
@@ -145,6 +145,8 @@ import java.util.Set;\n
 import java.util.stream.Collectors;\n
 import java.util.function.Function;\n
 import io.vertx.serviceproxy.ProxyHelper;\n
+import io.vertx.serviceproxy.ServiceException;\n
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;\n
 @foreach{importedType:importedTypes}
 	@if{!importedType.packageName.equals("java.lang")}
 		import @{importedType};\n
@@ -170,6 +172,10 @@ public class @{ifaceSimpleName}VertxEBProxy implements @{ifaceSimpleName} {\n
     this._vertx = vertx;\n
     this._address = address;\n
     this._options = options;\n
+    try {\n
+      this._vertx.eventBus().registerDefaultCodec(ServiceException.class,\n
+          new ServiceExceptionMessageCodec());\n
+    } catch (IllegalStateException ex) {}\n
   }\n
 \n
 @foreach{method:methods}

--- a/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxEBProxy.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.serviceproxy.testmodel.SomeVertxEnum;
 import io.vertx.core.json.JsonArray;
@@ -60,6 +62,10 @@ public class ServiceVertxEBProxy implements Service {
     this._vertx = vertx;
     this._address = address;
     this._options = options;
+    try {
+      this._vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
   }
 
   public Service hello(String name, Handler<AsyncResult<String>> result) {
@@ -245,6 +251,25 @@ public class ServiceVertxEBProxy implements Service {
         result.handle(Future.failedFuture(res.cause()));
       } else {
         result.handle(Future.succeededFuture(convertList(res.result().body().getList())));
+      }
+    });
+    return this;
+  }
+
+  public Service methodWthFailingResult(String input, Handler<AsyncResult<JsonObject>> result) {
+    if (closed) {
+      result.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return this;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("input", input);
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "methodWthFailingResult");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        result.handle(Future.failedFuture(res.cause()));
+      } else {
+        result.handle(Future.succeededFuture(res.result().body()));
       }
     });
     return this;

--- a/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxProxyHandler.java
@@ -196,7 +196,7 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
         }
       }
     } catch (Throwable t) {
-      msg.reply(new ServiceException(-1, t.getMessage()));
+      msg.reply(new ServiceException(500, t.getMessage()));
       throw t;
     }
   }

--- a/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/clustered/ServiceVertxProxyHandler.java
@@ -37,6 +37,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.serviceproxy.testmodel.SomeVertxEnum;
 import io.vertx.core.json.JsonArray;
@@ -74,6 +76,10 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
     this.vertx = vertx;
     this.service = service;
     this.timeoutSeconds = timeoutSeconds;
+    try {
+      this.vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
     if (timeoutSeconds != -1 && !topLevel) {
       long period = timeoutSeconds * 1000 / 2;
       if (period > 10000) {
@@ -152,7 +158,11 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
         case "methodWithDataObject": {
           service.methodWithDataObject(json.getJsonObject("data") == null ? null : new io.vertx.serviceproxy.testmodel.TestDataObject(json.getJsonObject("data")), res -> {
             if (res.failed()) {
-              msg.fail(-1, res.cause().getMessage());
+              if (res.cause() instanceof ServiceException) {
+                msg.reply(res.cause());
+              } else {
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));
+              }
             } else {
               msg.reply(res.result() == null ? null : res.result().toJson());
             }
@@ -162,7 +172,11 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
         case "methodWithListOfDataObject": {
           service.methodWithListOfDataObject(json.getJsonArray("list").stream().map(o -> new TestDataObject((JsonObject)o)).collect(Collectors.toList()), res -> {
             if (res.failed()) {
-              msg.fail(-1, res.cause().getMessage());
+              if (res.cause() instanceof ServiceException) {
+                msg.reply(res.cause());
+              } else {
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));
+              }
             } else {
               msg.reply(new JsonArray(res.result().stream().map(TestDataObject::toJson).collect(Collectors.toList())));
             }
@@ -173,12 +187,16 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
           service.methodWithListOfJsonObject(convertList(json.getJsonArray("list").getList()), createListHandler(msg));
           break;
         }
+        case "methodWthFailingResult": {
+          service.methodWthFailingResult((java.lang.String)json.getValue("input"), createHandler(msg));
+          break;
+        }
         default: {
           throw new IllegalStateException("Invalid action: " + action);
         }
       }
     } catch (Throwable t) {
-      msg.fail(-1, t.getMessage());
+      msg.reply(new ServiceException(-1, t.getMessage()));
       throw t;
     }
   }
@@ -186,16 +204,29 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
   private <T> Handler<AsyncResult<T>> createHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
-        if (res.result() != null  && res.result().getClass().isEnum()) {          msg.reply(((Enum) res.result()).name());        } else {          msg.reply(res.result());        }      }
+        if (res.result() != null  && res.result().getClass().isEnum()) {
+          msg.reply(((Enum) res.result()).name());
+        } else {
+          msg.reply(res.result());
+        }
+      }
     };
   }
 
   private <T> Handler<AsyncResult<List<T>>> createListHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(res.result()));
       }
@@ -205,7 +236,11 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
   private <T> Handler<AsyncResult<Set<T>>> createSetHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(new ArrayList<>(res.result())));
       }
@@ -215,7 +250,11 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
   private Handler<AsyncResult<List<Character>>> createListCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {
@@ -229,7 +268,11 @@ public class ServiceVertxProxyHandler extends ProxyHandler {
   private Handler<AsyncResult<Set<Character>>> createSetCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxEBProxy.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 
 /*
   Generated Proxy code - DO NOT EDIT
@@ -50,6 +52,10 @@ public class TestBaseImportsServiceVertxEBProxy implements TestBaseImportsServic
     this._vertx = vertx;
     this._address = address;
     this._options = options;
+    try {
+      this._vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
   }
 
   public void m() {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxProxyHandler.java
@@ -37,6 +37,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 
 /*
   Generated Proxy code - DO NOT EDIT
@@ -64,6 +66,10 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
     this.vertx = vertx;
     this.service = service;
     this.timeoutSeconds = timeoutSeconds;
+    try {
+      this.vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
     if (timeoutSeconds != -1 && !topLevel) {
       long period = timeoutSeconds * 1000 / 2;
       if (period > 10000) {
@@ -119,7 +125,7 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
         }
       }
     } catch (Throwable t) {
-      msg.fail(-1, t.getMessage());
+      msg.reply(new ServiceException(-1, t.getMessage()));
       throw t;
     }
   }
@@ -127,16 +133,29 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
   private <T> Handler<AsyncResult<T>> createHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
-        if (res.result() != null  && res.result().getClass().isEnum()) {          msg.reply(((Enum) res.result()).name());        } else {          msg.reply(res.result());        }      }
+        if (res.result() != null  && res.result().getClass().isEnum()) {
+          msg.reply(((Enum) res.result()).name());
+        } else {
+          msg.reply(res.result());
+        }
+      }
     };
   }
 
   private <T> Handler<AsyncResult<List<T>>> createListHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(res.result()));
       }
@@ -146,7 +165,11 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
   private <T> Handler<AsyncResult<Set<T>>> createSetHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(new ArrayList<>(res.result())));
       }
@@ -156,7 +179,11 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
   private Handler<AsyncResult<List<Character>>> createListCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {
@@ -170,7 +197,11 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
   private Handler<AsyncResult<Set<Character>>> createSetCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestBaseImportsServiceVertxProxyHandler.java
@@ -125,7 +125,7 @@ public class TestBaseImportsServiceVertxProxyHandler extends ProxyHandler {
         }
       }
     } catch (Throwable t) {
-      msg.reply(new ServiceException(-1, t.getMessage()));
+      msg.reply(new ServiceException(500, t.getMessage()));
       throw t;
     }
   }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxEBProxy.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.testmodel.TestConnection;
 import io.vertx.core.AsyncResult;
@@ -54,6 +56,10 @@ public class TestConnectionVertxEBProxy implements TestConnection {
     this._vertx = vertx;
     this._address = address;
     this._options = options;
+    try {
+      this._vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
   }
 
   public TestConnection startTransaction(Handler<AsyncResult<String>> resultHandler) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
@@ -147,7 +147,7 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
         }
       }
     } catch (Throwable t) {
-      msg.reply(new ServiceException(-1, t.getMessage()));
+      msg.reply(new ServiceException(500, t.getMessage()));
       throw t;
     }
   }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionVertxProxyHandler.java
@@ -37,6 +37,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.testmodel.TestConnection;
 import io.vertx.core.AsyncResult;
@@ -68,6 +70,10 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
     this.vertx = vertx;
     this.service = service;
     this.timeoutSeconds = timeoutSeconds;
+    try {
+      this.vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
     if (timeoutSeconds != -1 && !topLevel) {
       long period = timeoutSeconds * 1000 / 2;
       if (period > 10000) {
@@ -141,7 +147,7 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
         }
       }
     } catch (Throwable t) {
-      msg.fail(-1, t.getMessage());
+      msg.reply(new ServiceException(-1, t.getMessage()));
       throw t;
     }
   }
@@ -149,16 +155,29 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
   private <T> Handler<AsyncResult<T>> createHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
-        if (res.result() != null  && res.result().getClass().isEnum()) {          msg.reply(((Enum) res.result()).name());        } else {          msg.reply(res.result());        }      }
+        if (res.result() != null  && res.result().getClass().isEnum()) {
+          msg.reply(((Enum) res.result()).name());
+        } else {
+          msg.reply(res.result());
+        }
+      }
     };
   }
 
   private <T> Handler<AsyncResult<List<T>>> createListHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(res.result()));
       }
@@ -168,7 +187,11 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
   private <T> Handler<AsyncResult<Set<T>>> createSetHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(new ArrayList<>(res.result())));
       }
@@ -178,7 +201,11 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
   private Handler<AsyncResult<List<Character>>> createListCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {
@@ -192,7 +219,11 @@ public class TestConnectionVertxProxyHandler extends ProxyHandler {
   private Handler<AsyncResult<Set<Character>>> createSetCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxEBProxy.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 
@@ -52,6 +54,10 @@ public class TestConnectionWithCloseFutureVertxEBProxy implements TestConnection
     this._vertx = vertx;
     this._address = address;
     this._options = options;
+    try {
+      this._vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
   }
 
   public void close(Handler<AsyncResult<Void>> handler) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
@@ -133,7 +133,7 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
         }
       }
     } catch (Throwable t) {
-      msg.reply(new ServiceException(-1, t.getMessage()));
+      msg.reply(new ServiceException(500, t.getMessage()));
       throw t;
     }
   }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestConnectionWithCloseFutureVertxProxyHandler.java
@@ -37,6 +37,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Handler;
 
@@ -66,6 +68,10 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
     this.vertx = vertx;
     this.service = service;
     this.timeoutSeconds = timeoutSeconds;
+    try {
+      this.vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
     if (timeoutSeconds != -1 && !topLevel) {
       long period = timeoutSeconds * 1000 / 2;
       if (period > 10000) {
@@ -127,7 +133,7 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
         }
       }
     } catch (Throwable t) {
-      msg.fail(-1, t.getMessage());
+      msg.reply(new ServiceException(-1, t.getMessage()));
       throw t;
     }
   }
@@ -135,16 +141,29 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
   private <T> Handler<AsyncResult<T>> createHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
-        if (res.result() != null  && res.result().getClass().isEnum()) {          msg.reply(((Enum) res.result()).name());        } else {          msg.reply(res.result());        }      }
+        if (res.result() != null  && res.result().getClass().isEnum()) {
+          msg.reply(((Enum) res.result()).name());
+        } else {
+          msg.reply(res.result());
+        }
+      }
     };
   }
 
   private <T> Handler<AsyncResult<List<T>>> createListHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(res.result()));
       }
@@ -154,7 +173,11 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
   private <T> Handler<AsyncResult<Set<T>>> createSetHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(new ArrayList<>(res.result())));
       }
@@ -164,7 +187,11 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
   private Handler<AsyncResult<List<Character>>> createListCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {
@@ -178,7 +205,11 @@ public class TestConnectionWithCloseFutureVertxProxyHandler extends ProxyHandler
   private Handler<AsyncResult<Set<Character>>> createSetCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxEBProxy.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxEBProxy.java
@@ -30,6 +30,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.function.Function;
 import io.vertx.serviceproxy.ProxyHelper;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 import io.vertx.serviceproxy.testmodel.TestService;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.core.Vertx;
@@ -63,6 +65,10 @@ public class TestServiceVertxEBProxy implements TestService {
     this._vertx = vertx;
     this._address = address;
     this._options = options;
+    try {
+      this._vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
   }
 
   public void longDeliverySuccess(Handler<AsyncResult<String>> resultHandler) {
@@ -1256,6 +1262,24 @@ public class TestServiceVertxEBProxy implements TestService {
         resultHandler.handle(Future.failedFuture(res.cause()));
       } else {
         resultHandler.handle(Future.succeededFuture(res.result().body().stream().map(o -> o instanceof Map ? new TestDataObject(new JsonObject((Map) o)) : new TestDataObject((JsonObject) o)).collect(Collectors.toSet())));
+      }
+    });
+  }
+
+  public void failingCall(String value, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (closed) {
+      resultHandler.handle(Future.failedFuture(new IllegalStateException("Proxy is closed")));
+      return;
+    }
+    JsonObject _json = new JsonObject();
+    _json.put("value", value);
+    DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions();
+    _deliveryOptions.addHeader("action", "failingCall");
+    _vertx.eventBus().<JsonObject>send(_address, _json, _deliveryOptions, res -> {
+      if (res.failed()) {
+        resultHandler.handle(Future.failedFuture(res.cause()));
+      } else {
+        resultHandler.handle(Future.succeededFuture(res.result().body()));
       }
     });
   }

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
@@ -37,6 +37,8 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.ProxyHandler;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
 import io.vertx.serviceproxy.testmodel.TestService;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.core.Vertx;
@@ -77,6 +79,10 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
     this.vertx = vertx;
     this.service = service;
     this.timeoutSeconds = timeoutSeconds;
+    try {
+      this.vertx.eventBus().registerDefaultCodec(ServiceException.class,
+          new ServiceExceptionMessageCodec());
+    } catch (IllegalStateException ex) {}
     if (timeoutSeconds != -1 && !topLevel) {
       long period = timeoutSeconds * 1000 / 2;
       if (period > 10000) {
@@ -137,7 +143,11 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
         case "createConnection": {
           service.createConnection((java.lang.String)json.getValue("str"), res -> {
             if (res.failed()) {
-              msg.fail(-1, res.cause().getMessage());
+                if (res.cause() instanceof ServiceException) {
+                  msg.reply(res.cause());
+                } else {
+                  msg.reply(new ServiceException(-1, res.cause().getMessage()));
+                }
             } else {
               String proxyAddress = UUID.randomUUID().toString();
               ProxyHelper.registerService(TestConnection.class, vertx, res.result(), proxyAddress, false, timeoutSeconds);
@@ -149,7 +159,11 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
         case "createConnectionWithCloseFuture": {
           service.createConnectionWithCloseFuture(res -> {
             if (res.failed()) {
-              msg.fail(-1, res.cause().getMessage());
+                if (res.cause() instanceof ServiceException) {
+                  msg.reply(res.cause());
+                } else {
+                  msg.reply(new ServiceException(-1, res.cause().getMessage()));
+                }
             } else {
               String proxyAddress = UUID.randomUUID().toString();
               ProxyHelper.registerService(TestConnectionWithCloseFuture.class, vertx, res.result(), proxyAddress, false, timeoutSeconds);
@@ -309,7 +323,11 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
         case "dataObjectHandler": {
           service.dataObjectHandler(res -> {
             if (res.failed()) {
-              msg.fail(-1, res.cause().getMessage());
+              if (res.cause() instanceof ServiceException) {
+                msg.reply(res.cause());
+              } else {
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));
+              }
             } else {
               msg.reply(res.result() == null ? null : res.result().toJson());
             }
@@ -319,7 +337,11 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
         case "dataObjectNullHandler": {
           service.dataObjectNullHandler(res -> {
             if (res.failed()) {
-              msg.fail(-1, res.cause().getMessage());
+              if (res.cause() instanceof ServiceException) {
+                msg.reply(res.cause());
+              } else {
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));
+              }
             } else {
               msg.reply(res.result() == null ? null : res.result().toJson());
             }
@@ -393,7 +415,11 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
         case "listDataObjectHandler": {
           service.listDataObjectHandler(res -> {
             if (res.failed()) {
-              msg.fail(-1, res.cause().getMessage());
+              if (res.cause() instanceof ServiceException) {
+                msg.reply(res.cause());
+              } else {
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));
+              }
             } else {
               msg.reply(new JsonArray(res.result().stream().map(TestDataObject::toJson).collect(Collectors.toList())));
             }
@@ -447,11 +473,19 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
         case "setDataObjectHandler": {
           service.setDataObjectHandler(res -> {
             if (res.failed()) {
-              msg.fail(-1, res.cause().getMessage());
+              if (res.cause() instanceof ServiceException) {
+                msg.reply(res.cause());
+              } else {
+                msg.reply(new ServiceException(-1, res.cause().getMessage()));
+              }
             } else {
               msg.reply(new JsonArray(res.result().stream().map(TestDataObject::toJson).collect(Collectors.toList())));
             }
          });
+          break;
+        }
+        case "failingCall": {
+          service.failingCall((java.lang.String)json.getValue("value"), createHandler(msg));
           break;
         }
         case "ignoredMethod": {
@@ -463,7 +497,7 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
         }
       }
     } catch (Throwable t) {
-      msg.fail(-1, t.getMessage());
+      msg.reply(new ServiceException(-1, t.getMessage()));
       throw t;
     }
   }
@@ -471,16 +505,29 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
   private <T> Handler<AsyncResult<T>> createHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
-        if (res.result() != null  && res.result().getClass().isEnum()) {          msg.reply(((Enum) res.result()).name());        } else {          msg.reply(res.result());        }      }
+        if (res.result() != null  && res.result().getClass().isEnum()) {
+          msg.reply(((Enum) res.result()).name());
+        } else {
+          msg.reply(res.result());
+        }
+      }
     };
   }
 
   private <T> Handler<AsyncResult<List<T>>> createListHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(res.result()));
       }
@@ -490,7 +537,11 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
   private <T> Handler<AsyncResult<Set<T>>> createSetHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         msg.reply(new JsonArray(new ArrayList<>(res.result())));
       }
@@ -500,7 +551,11 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
   private Handler<AsyncResult<List<Character>>> createListCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {
@@ -514,7 +569,11 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
   private Handler<AsyncResult<Set<Character>>> createSetCharHandler(Message msg) {
     return res -> {
       if (res.failed()) {
-        msg.fail(-1, res.cause().getMessage());
+        if (res.cause() instanceof ServiceException) {
+          msg.reply(res.cause());
+        } else {
+          msg.reply(new ServiceException(-1, res.cause().getMessage()));
+        }
       } else {
         JsonArray arr = new JsonArray();
         for (Character chr: res.result()) {

--- a/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
+++ b/src/test/generated/io/vertx/serviceproxy/testmodel/TestServiceVertxProxyHandler.java
@@ -497,7 +497,7 @@ public class TestServiceVertxProxyHandler extends ProxyHandler {
         }
       }
     } catch (Throwable t) {
-      msg.reply(new ServiceException(-1, t.getMessage()));
+      msg.reply(new ServiceException(500, t.getMessage()));
       throw t;
     }
   }

--- a/src/test/java/io/vertx/serviceproxy/clustered/ClusteredTest.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/ClusteredTest.java
@@ -209,6 +209,7 @@ public class ClusteredTest {
     service.methodWthFailingResult("Fail", ar -> {
       assertThat(ar.cause() instanceof ServiceException).isTrue();
       assertThat(((ServiceException)ar.cause()).failureCode()).isEqualTo(30);
+      assertThat(((ServiceException)ar.cause()).getDebugInfo()).isEqualTo(new JsonObject().put("test", "val"));
       result.set(ar.cause());
     });
     Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> result.get() != null);

--- a/src/test/java/io/vertx/serviceproxy/clustered/ClusteredTest.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/ClusteredTest.java
@@ -3,8 +3,13 @@ package io.vertx.serviceproxy.clustered;
 import com.jayway.awaitility.Awaitility;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
+import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceExceptionMessageCodec;
+import io.vertx.serviceproxy.testmodel.MyServiceException;
+import io.vertx.serviceproxy.testmodel.MyServiceExceptionMessageCodec;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.serviceproxy.testmodel.SomeVertxEnum;
 import io.vertx.serviceproxy.testmodel.TestDataObject;
@@ -32,12 +37,16 @@ public class ClusteredTest {
   public void setUp() {
     Vertx.clusteredVertx(new VertxOptions().setClustered(true).setClusterHost("127.0.0.1"), ar -> {
       Vertx vertx = ar.result();
+      vertx.eventBus().registerDefaultCodec(MyServiceException.class,
+          new MyServiceExceptionMessageCodec());
       providerNode.set(vertx);
       vertx.deployVerticle(ServiceProviderVerticle.class.getName());
     });
 
     Vertx.clusteredVertx(new VertxOptions().setClustered(true).setClusterHost("127.0.0.1"), ar -> {
       Vertx vertx = ar.result();
+      vertx.eventBus().registerDefaultCodec(MyServiceException.class,
+          new MyServiceExceptionMessageCodec());
       consumerNode.set(vertx);
     });
 
@@ -191,5 +200,30 @@ public class ClusteredTest {
     assertThat(out.getNumber()).isEqualTo(25);
     assertThat(out.isBool()).isTrue();
     assertThat(out.getString()).isEqualTo("vert.x");
+  }
+
+  @Test
+  public void testWithFailingResult() {
+    AtomicReference<Throwable> result = new AtomicReference<>();
+    Service service = Service.createProxy(consumerNode.get(), "my.service");
+    service.methodWthFailingResult("Fail", ar -> {
+      assertThat(ar.cause() instanceof ServiceException).isTrue();
+      assertThat(((ServiceException)ar.cause()).failureCode()).isEqualTo(30);
+      result.set(ar.cause());
+    });
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> result.get() != null);
+  }
+
+  @Test
+  public void testWithFailingResultServiceExceptionSubclass() {
+    AtomicReference<Throwable> result = new AtomicReference<>();
+    Service service = Service.createProxy(consumerNode.get(), "my.service");
+    service.methodWthFailingResult("cluster Fail", ar -> {
+      assertThat(ar.cause() instanceof MyServiceException).isTrue();
+      assertThat(((MyServiceException)ar.cause()).failureCode()).isEqualTo(30);
+      assertThat(((MyServiceException)ar.cause()).getExtra()).isEqualTo("some extra");
+      result.set(ar.cause());
+    });
+    Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> result.get() != null);
   }
 }

--- a/src/test/java/io/vertx/serviceproxy/clustered/Service.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/Service.java
@@ -62,6 +62,9 @@ public interface Service {
   Service methodWithListOfJsonObject(List<JsonObject> list,
                                      Handler<AsyncResult<List<JsonObject>>> result);
 
+  @Fluent
+  Service methodWthFailingResult(String input, Handler<AsyncResult<JsonObject>> result);
+
   /*@Fluent
   Service methodWithMapOfJsonObject(Map<String, JsonObject> map,
                                     Handler<AsyncResult<Map<String, JsonObject>>> result);

--- a/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
@@ -3,8 +3,12 @@ package io.vertx.serviceproxy.clustered;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.eventbus.ReplyFailure;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.testmodel.MyServiceException;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.serviceproxy.testmodel.SomeVertxEnum;
 import io.vertx.serviceproxy.testmodel.TestDataObject;
@@ -77,6 +81,16 @@ public class ServiceProvider implements Service {
   @Override
   public Service methodWithListOfJsonObject(List<JsonObject> list, Handler<AsyncResult<List<JsonObject>>> result) {
     result.handle(Future.succeededFuture(list));
+    return this;
+  }
+
+  @Override
+  public Service methodWthFailingResult(String input, Handler<AsyncResult<JsonObject>> result) {
+    if (input.equals("Fail")) {
+      result.handle(ServiceException.fail(30, "failed!"));
+    } else {
+      result.handle(MyServiceException.fail(30, "failed!", "some extra"));
+    }
     return this;
   }
 

--- a/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
+++ b/src/test/java/io/vertx/serviceproxy/clustered/ServiceProvider.java
@@ -87,7 +87,7 @@ public class ServiceProvider implements Service {
   @Override
   public Service methodWthFailingResult(String input, Handler<AsyncResult<JsonObject>> result) {
     if (input.equals("Fail")) {
-      result.handle(ServiceException.fail(30, "failed!"));
+      result.handle(ServiceException.fail(30, "failed!", new JsonObject().put("test", "val")));
     } else {
       result.handle(MyServiceException.fail(30, "failed!", "some extra"));
     }

--- a/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
+++ b/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
@@ -862,6 +862,7 @@ public class ServiceProxyTest extends VertxTestBase {
           conn.startTransaction(onFailure(cause -> {
             assertNotNull(cause);
             assertTrue(cause instanceof ReplyException);
+            assertFalse(cause instanceof ServiceException);
             ReplyException re = (ReplyException) cause;
             assertEquals(ReplyFailure.NO_HANDLERS, re.failureType());
             testComplete();
@@ -896,6 +897,7 @@ public class ServiceProxyTest extends VertxTestBase {
         conn.someMethod(onFailure(cause -> {
           assertNotNull(cause);
           assertTrue(cause instanceof ReplyException);
+          assertFalse(cause instanceof ServiceException);
           ReplyException re = (ReplyException) cause;
           assertEquals(ReplyFailure.NO_HANDLERS, re.failureType());
           testComplete();
@@ -922,6 +924,7 @@ public class ServiceProxyTest extends VertxTestBase {
     proxyLong.longDeliveryFailed(onFailure(t -> {
       assertNotNull(t);
       assertTrue(t instanceof ReplyException);
+      assertFalse(t instanceof ServiceException);
       ReplyException re = (ReplyException) t;
       assertEquals(ReplyFailure.TIMEOUT, re.failureType());
       testComplete();

--- a/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
+++ b/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
@@ -76,6 +76,7 @@ public class ServiceProxyTest extends VertxTestBase {
       assertTrue(handler.cause() instanceof ServiceException);
       assertEquals("Call has failed", handler.cause().getMessage());
       assertEquals(25, ((ServiceException)handler.cause()).failureCode());
+      assertEquals(new JsonObject().put("test", "val"), ((ServiceException)handler.cause()).getDebugInfo());
       testComplete();
     });
     await();

--- a/src/test/java/io/vertx/serviceproxy/testmodel/MyServiceException.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/MyServiceException.java
@@ -1,0 +1,44 @@
+package io.vertx.serviceproxy.testmodel;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.serviceproxy.ServiceException;
+
+/**
+ * @author <a href="mailto:oreilldf@gmail.com">Dan O'Reilly</a>
+ */
+public class MyServiceException extends ServiceException {
+  private final String extra;
+  /**
+   * Create a ServiceException.
+   *
+   * @param failureCode The failure code.
+   * @param message     The failure message.
+   */
+  public MyServiceException(int failureCode, String message, String extra) {
+    super(failureCode, message);
+    this.extra = extra;
+  }
+
+  /**
+   * Get the extra data
+   *
+   * @return The extra data
+   */
+  public String getExtra() {
+    return extra;
+  }
+
+  /**
+   * Wrap and MyServiceException in a failed Future and return it.
+   *
+   * @param failureCode The failure code.
+   * @param message     The failure message.
+   * @param extra       The extra data
+   * @param <T>         The type returned if the Future succeeds.
+   * @return The MyServiceException wrapped in a failed future.
+   */
+  public static <T> AsyncResult<T> fail(int failureCode, String message, String extra) {
+    return Future.failedFuture(new MyServiceException(failureCode, message, extra));
+  }
+}

--- a/src/test/java/io/vertx/serviceproxy/testmodel/MyServiceException.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/MyServiceException.java
@@ -2,6 +2,7 @@ package io.vertx.serviceproxy.testmodel;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ServiceException;
 
 /**
@@ -17,6 +18,11 @@ public class MyServiceException extends ServiceException {
    */
   public MyServiceException(int failureCode, String message, String extra) {
     super(failureCode, message);
+    this.extra = extra;
+  }
+
+  public MyServiceException(int failureCode, String message, JsonObject debugInfo, String extra) {
+    super(failureCode, message, debugInfo);
     this.extra = extra;
   }
 

--- a/src/test/java/io/vertx/serviceproxy/testmodel/MyServiceExceptionMessageCodec.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/MyServiceExceptionMessageCodec.java
@@ -3,6 +3,7 @@ package io.vertx.serviceproxy.testmodel;
 import io.netty.util.CharsetUtil;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.eventbus.MessageCodec;
+import io.vertx.core.json.JsonObject;
 
 /**
  * @author <a href="mailto:oreilldf@gmail.com">Dan O'Reilly</a>
@@ -28,6 +29,7 @@ public class MyServiceExceptionMessageCodec  implements
       buffer.appendInt(encoded.length);
       buffer.appendBytes(encoded);
     }
+    body.getDebugInfo().writeToBuffer(buffer);
   }
 
   @Override
@@ -47,17 +49,20 @@ public class MyServiceExceptionMessageCodec  implements
       message = null;
     }
     isNull = buffer.getByte(pos) == (byte)0;
+    pos++;
     String extra;
     if (!isNull) {
-      pos++;
       int strLength = buffer.getInt(pos);
       pos += 4;
       byte[] bytes = buffer.getBytes(pos, pos + strLength);
       extra = new String(bytes, CharsetUtil.UTF_8);
+      pos += strLength;
     } else {
       extra = null;
     }
-    return new MyServiceException(failureCode, message, extra);
+    JsonObject debugInfo = new JsonObject();
+    debugInfo.readFromBuffer(pos, buffer);
+    return new MyServiceException(failureCode, message, debugInfo, extra);
   }
 
   @Override

--- a/src/test/java/io/vertx/serviceproxy/testmodel/MyServiceExceptionMessageCodec.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/MyServiceExceptionMessageCodec.java
@@ -1,0 +1,77 @@
+package io.vertx.serviceproxy.testmodel;
+
+import io.netty.util.CharsetUtil;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.eventbus.MessageCodec;
+
+/**
+ * @author <a href="mailto:oreilldf@gmail.com">Dan O'Reilly</a>
+ */
+public class MyServiceExceptionMessageCodec  implements
+    MessageCodec<MyServiceException, MyServiceException> {
+  @Override
+  public void encodeToWire(Buffer buffer, MyServiceException body) {
+    buffer.appendInt(body.failureCode());
+    if (body.getMessage() == null) {
+      buffer.appendByte((byte)0);
+    } else {
+      buffer.appendByte((byte)1);
+      byte[] encoded = body.getMessage().getBytes(CharsetUtil.UTF_8);
+      buffer.appendInt(encoded.length);
+      buffer.appendBytes(encoded);
+    }
+    if (body.getExtra() == null) {
+      buffer.appendByte((byte)0);
+    } else {
+      buffer.appendByte((byte)1);
+      byte[] encoded = body.getExtra().getBytes(CharsetUtil.UTF_8);
+      buffer.appendInt(encoded.length);
+      buffer.appendBytes(encoded);
+    }
+  }
+
+  @Override
+  public MyServiceException decodeFromWire(int pos, Buffer buffer) {
+    int failureCode = buffer.getInt(pos);
+    pos += 4;
+    boolean isNull = buffer.getByte(pos) == (byte)0;
+    pos++;
+    String message;
+    if (!isNull) {
+      int strLength = buffer.getInt(pos);
+      pos += 4;
+      byte[] bytes = buffer.getBytes(pos, pos + strLength);
+      pos += strLength;
+      message = new String(bytes, CharsetUtil.UTF_8);
+    } else {
+      message = null;
+    }
+    isNull = buffer.getByte(pos) == (byte)0;
+    String extra;
+    if (!isNull) {
+      pos++;
+      int strLength = buffer.getInt(pos);
+      pos += 4;
+      byte[] bytes = buffer.getBytes(pos, pos + strLength);
+      extra = new String(bytes, CharsetUtil.UTF_8);
+    } else {
+      extra = null;
+    }
+    return new MyServiceException(failureCode, message, extra);
+  }
+
+  @Override
+  public MyServiceException transform(MyServiceException e) {
+    return e;
+  }
+
+  @Override
+  public String name() {
+    return "myServiceException";
+  }
+
+  @Override
+  public byte systemCodecID() {
+    return -1;
+  }
+}

--- a/src/test/java/io/vertx/serviceproxy/testmodel/TestDataObject.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/TestDataObject.java
@@ -32,11 +32,6 @@ public class TestDataObject {
   public TestDataObject() {
   }
 
-  public TestDataObject(TestDataObject other) {
-    this.number = other.number;
-    this.string = other.string;
-    this.bool = other.bool;
-  }
 
   public TestDataObject(JsonObject json) {
     this.number = json.getInteger("number");

--- a/src/test/java/io/vertx/serviceproxy/testmodel/TestService.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/TestService.java
@@ -16,6 +16,10 @@
 
 package io.vertx.serviceproxy.testmodel;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import io.vertx.codegen.annotations.Fluent;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.annotations.ProxyIgnore;
@@ -28,10 +32,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.serviceproxy.ProxyHelper;
 import io.vertx.serviceproxy.testmodel.impl.TestServiceImpl;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * @author <a href="http://tfox.org">Tim Fox</a>
@@ -201,6 +201,8 @@ public interface TestService {
   void setJsonArrayHandler(Handler<AsyncResult<Set<JsonArray>>> resultHandler);
 
   void setDataObjectHandler(Handler<AsyncResult<Set<TestDataObject>>> resultHandler);
+
+  void failingCall(String value, Handler<AsyncResult<JsonObject>> resultHandler);
 
   @ProxyIgnore
   void ignoredMethod();

--- a/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestServiceImpl.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestServiceImpl.java
@@ -547,7 +547,7 @@ public class TestServiceImpl implements TestService {
   @Override
   public void failingCall(String value, Handler<AsyncResult<JsonObject>> resultHandler) {
     if (value.equals("Fail")) {
-      resultHandler.handle(ServiceException.fail(25, "Call has failed"));
+      resultHandler.handle(ServiceException.fail(25, "Call has failed", new JsonObject().put("test", "val")));
     } else if (value.equals("Fail subclass")) {
       resultHandler.handle(MyServiceException.fail(25, "Call has failed", "some extra"));
     } else {

--- a/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestServiceImpl.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestServiceImpl.java
@@ -23,7 +23,9 @@ import io.vertx.core.Vertx;
 import io.vertx.core.VertxException;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.ServiceException;
 import io.vertx.serviceproxy.test.ServiceProxyTest;
+import io.vertx.serviceproxy.testmodel.MyServiceException;
 import io.vertx.serviceproxy.testmodel.SomeEnum;
 import io.vertx.serviceproxy.testmodel.TestConnection;
 import io.vertx.serviceproxy.testmodel.TestConnectionWithCloseFuture;
@@ -31,7 +33,6 @@ import io.vertx.serviceproxy.testmodel.TestDataObject;
 import io.vertx.serviceproxy.testmodel.TestService;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -541,5 +542,16 @@ public class TestServiceImpl implements TestService {
     vertx.setTimer(30*1000L, tid -> {
       resultHandler.handle(Future.succeededFuture("blah"));
     });
+  }
+
+  @Override
+  public void failingCall(String value, Handler<AsyncResult<JsonObject>> resultHandler) {
+    if (value.equals("Fail")) {
+      resultHandler.handle(ServiceException.fail(25, "Call has failed"));
+    } else if (value.equals("Fail subclass")) {
+      resultHandler.handle(MyServiceException.fail(25, "Call has failed", "some extra"));
+    } else {
+      resultHandler.handle(Future.succeededFuture(new JsonObject()));
+    }
   }
 }

--- a/src/test/resources/test-js/service.js
+++ b/src/test/resources/test-js/service.js
@@ -63,7 +63,7 @@ var Service = function(j_val) {
   this.methodUsingEnum = function(e, result) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
-      j_service["methodUsingEnum(io.vertx.serviceproxy.testmodel.SomeEnum,io.vertx.core.Handler)"](io.vertx.serviceproxy.testmodel.SomeEnum.valueOf(__args[0]), function(ar) {
+      j_service["methodUsingEnum(io.vertx.serviceproxy.testmodel.SomeEnum,io.vertx.core.Handler)"](io.vertx.serviceproxy.testmodel.SomeEnum.valueOf(e), function(ar) {
       if (ar.succeeded()) {
         result(ar.result(), null);
       } else {
@@ -166,7 +166,7 @@ var Service = function(j_val) {
   this.methodWithList = function(list, result) {
     var __args = arguments;
     if (__args.length === 2 && typeof __args[0] === 'object' && __args[0] instanceof Array && typeof __args[1] === 'function') {
-      j_service["methodWithList(java.util.List,io.vertx.core.Handler)"](list, function(ar) {
+      j_service["methodWithList(java.util.List,io.vertx.core.Handler)"](utils.convParamListBasicOther(list), function(ar) {
       if (ar.succeeded()) {
         result(ar.result(), null);
       } else {
@@ -232,6 +232,27 @@ var Service = function(j_val) {
       j_service["methodWithListOfJsonObject(java.util.List,io.vertx.core.Handler)"](utils.convParamListJsonObject(list), function(ar) {
       if (ar.succeeded()) {
         result(utils.convReturnListSetJson(ar.result()), null);
+      } else {
+        result(null, ar.cause());
+      }
+    });
+      return that;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param input {string} 
+   @param result {function} 
+   @return {Service}
+   */
+  this.methodWthFailingResult = function(input, result) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      j_service["methodWthFailingResult(java.lang.String,io.vertx.core.Handler)"](input, function(ar) {
+      if (ar.succeeded()) {
+        result(utils.convReturnJson(ar.result()), null);
       } else {
         result(null, ar.cause());
       }

--- a/src/test/resources/test-js/test_error_handling.js
+++ b/src/test/resources/test-js/test_error_handling.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** @module test-js/test_error_handling */
+var utils = require('vertx-js/util/utils');
+var Vertx = require('vertx-js/vertx');
+
+var io = Packages.io;
+var JsonObject = io.vertx.core.json.JsonObject;
+var JTestErrorHandling = io.vertx.serviceproxy.testmodel.TestErrorHandling;
+
+/**
+ Created by dan on 4/21/16.
+
+ @class
+*/
+var TestErrorHandling = function(j_val) {
+
+  var j_testErrorHandling = j_val;
+  var that = this;
+
+  /**
+
+   @public
+   @param value {string} 
+   @param resultHandler {function} 
+   */
+  this.failingCall = function(value, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      j_testErrorHandling["failingCall(java.lang.String,io.vertx.core.Handler)"](value, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  // A reference to the underlying Java delegate
+  // NOTE! This is an internal API and must not be used in user code.
+  // If you rely on this property your code is likely to break if we change it / remove it without warning.
+  this._jdel = j_testErrorHandling;
+};
+
+/**
+
+ @memberof module:test-js/test_error_handling
+ @param vertx {Vertx} 
+ @return {TestErrorHandling}
+ */
+TestErrorHandling.create = function(vertx) {
+  var __args = arguments;
+  if (__args.length === 1 && typeof __args[0] === 'object' && __args[0]._jdel) {
+    return utils.convReturnVertxGen(JTestErrorHandling["create(io.vertx.core.Vertx)"](vertx._jdel), TestErrorHandling);
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+/**
+
+ @memberof module:test-js/test_error_handling
+ @param vertx {Vertx} 
+ @param address {string} 
+ @return {TestErrorHandling}
+ */
+TestErrorHandling.createProxy = function(vertx, address) {
+  var __args = arguments;
+  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'string') {
+    return utils.convReturnVertxGen(JTestErrorHandling["createProxy(io.vertx.core.Vertx,java.lang.String)"](vertx._jdel, address), TestErrorHandling);
+  } else throw new TypeError('function invoked with invalid arguments');
+};
+
+// We export the Constructor function
+module.exports = TestErrorHandling;

--- a/src/test/resources/test-js/test_service.js
+++ b/src/test/resources/test-js/test_service.js
@@ -155,7 +155,7 @@ var TestService = function(j_val) {
   this.basicBoxedTypes = function(str, b, s, i, l, f, d, c, bool) {
     var __args = arguments;
     if (__args.length === 9 && typeof __args[0] === 'string' && typeof __args[1] ==='number' && typeof __args[2] ==='number' && typeof __args[3] ==='number' && typeof __args[4] ==='number' && typeof __args[5] ==='number' && typeof __args[6] ==='number' && typeof __args[7] ==='string' && typeof __args[8] ==='boolean') {
-      j_testService["basicBoxedTypes(java.lang.String,java.lang.Byte,java.lang.Short,java.lang.Integer,java.lang.Long,java.lang.Float,java.lang.Double,java.lang.Character,java.lang.Boolean)"](str, b, s, i, l, f, d, c, bool);
+      j_testService["basicBoxedTypes(java.lang.String,java.lang.Byte,java.lang.Short,java.lang.Integer,java.lang.Long,java.lang.Float,java.lang.Double,java.lang.Character,java.lang.Boolean)"](str, utils.convParamByte(b), utils.convParamShort(s), utils.convParamInteger(i), utils.convParamLong(l), utils.convParamFloat(f), utils.convParamDouble(d), utils.convParamCharacter(c), bool);
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -175,7 +175,7 @@ var TestService = function(j_val) {
   this.basicBoxedTypesNull = function(str, b, s, i, l, f, d, c, bool) {
     var __args = arguments;
     if (__args.length === 9 && typeof __args[0] === 'string' && typeof __args[1] ==='number' && typeof __args[2] ==='number' && typeof __args[3] ==='number' && typeof __args[4] ==='number' && typeof __args[5] ==='number' && typeof __args[6] ==='number' && typeof __args[7] ==='string' && typeof __args[8] ==='boolean') {
-      j_testService["basicBoxedTypesNull(java.lang.String,java.lang.Byte,java.lang.Short,java.lang.Integer,java.lang.Long,java.lang.Float,java.lang.Double,java.lang.Character,java.lang.Boolean)"](str, b, s, i, l, f, d, c, bool);
+      j_testService["basicBoxedTypesNull(java.lang.String,java.lang.Byte,java.lang.Short,java.lang.Integer,java.lang.Long,java.lang.Float,java.lang.Double,java.lang.Character,java.lang.Boolean)"](str, utils.convParamByte(b), utils.convParamShort(s), utils.convParamInteger(i), utils.convParamLong(l), utils.convParamFloat(f), utils.convParamDouble(d), utils.convParamCharacter(c), bool);
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -213,7 +213,7 @@ var TestService = function(j_val) {
   this.enumType = function(someEnum) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'string') {
-      j_testService["enumType(io.vertx.serviceproxy.testmodel.SomeEnum)"](io.vertx.serviceproxy.testmodel.SomeEnum.valueOf(__args[0]));
+      j_testService["enumType(io.vertx.serviceproxy.testmodel.SomeEnum)"](io.vertx.serviceproxy.testmodel.SomeEnum.valueOf(someEnum));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -225,7 +225,7 @@ var TestService = function(j_val) {
   this.enumTypeNull = function(someEnum) {
     var __args = arguments;
     if (__args.length === 1 && typeof __args[0] === 'string') {
-      j_testService["enumTypeNull(io.vertx.serviceproxy.testmodel.SomeEnum)"](io.vertx.serviceproxy.testmodel.SomeEnum.valueOf(__args[0]));
+      j_testService["enumTypeNull(io.vertx.serviceproxy.testmodel.SomeEnum)"](io.vertx.serviceproxy.testmodel.SomeEnum.valueOf(someEnum));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -304,7 +304,7 @@ var TestService = function(j_val) {
   this.listParams = function(listString, listByte, listShort, listInt, listLong, listJsonObject, listJsonArray, listDataObject) {
     var __args = arguments;
     if (__args.length === 8 && typeof __args[0] === 'object' && __args[0] instanceof Array && typeof __args[1] === 'object' && __args[1] instanceof Array && typeof __args[2] === 'object' && __args[2] instanceof Array && typeof __args[3] === 'object' && __args[3] instanceof Array && typeof __args[4] === 'object' && __args[4] instanceof Array && typeof __args[5] === 'object' && __args[5] instanceof Array && typeof __args[6] === 'object' && __args[6] instanceof Array && typeof __args[7] === 'object' && __args[7] instanceof Array) {
-      j_testService["listParams(java.util.List,java.util.List,java.util.List,java.util.List,java.util.List,java.util.List,java.util.List,java.util.List)"](listString, utils.convParamListByte(listByte), utils.convParamListShort(listShort), listInt, utils.convParamListLong(listLong), utils.convParamListJsonObject(listJsonObject), utils.convParamListJsonArray(listJsonArray), utils.convParamListDataObject(listDataObject, function(json) { return new TestDataObject(json); }));
+      j_testService["listParams(java.util.List,java.util.List,java.util.List,java.util.List,java.util.List,java.util.List,java.util.List,java.util.List)"](utils.convParamListBasicOther(listString), utils.convParamListByte(listByte), utils.convParamListShort(listShort), utils.convParamListBasicOther(listInt), utils.convParamListLong(listLong), utils.convParamListJsonObject(listJsonObject), utils.convParamListJsonArray(listJsonArray), utils.convParamListDataObject(listDataObject, function(json) { return new TestDataObject(json); }));
     } else throw new TypeError('function invoked with invalid arguments');
   };
 
@@ -861,7 +861,7 @@ var TestService = function(j_val) {
   this.invokeWithMessage = function(object, str, i, chr, senum, resultHandler) {
     var __args = arguments;
     if (__args.length === 6 && (typeof __args[0] === 'object' && __args[0] != null) && typeof __args[1] === 'string' && typeof __args[2] ==='number' && typeof __args[3] ==='string' && typeof __args[4] === 'string' && typeof __args[5] === 'function') {
-      j_testService["invokeWithMessage(io.vertx.core.json.JsonObject,java.lang.String,int,char,io.vertx.serviceproxy.testmodel.SomeEnum,io.vertx.core.Handler)"](utils.convParamJsonObject(object), str, i, chr, io.vertx.serviceproxy.testmodel.SomeEnum.valueOf(__args[4]), function(ar) {
+      j_testService["invokeWithMessage(io.vertx.core.json.JsonObject,java.lang.String,int,char,io.vertx.serviceproxy.testmodel.SomeEnum,io.vertx.core.Handler)"](utils.convParamJsonObject(object), str, i, chr, io.vertx.serviceproxy.testmodel.SomeEnum.valueOf(senum), function(ar) {
       if (ar.succeeded()) {
         resultHandler(ar.result(), null);
       } else {
@@ -1296,6 +1296,25 @@ var TestService = function(j_val) {
       j_testService["setDataObjectHandler(io.vertx.core.Handler)"](function(ar) {
       if (ar.succeeded()) {
         resultHandler(utils.convReturnListSetDataObject(ar.result()), null);
+      } else {
+        resultHandler(null, ar.cause());
+      }
+    });
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  /**
+
+   @public
+   @param value {string} 
+   @param resultHandler {function} 
+   */
+  this.failingCall = function(value, resultHandler) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'string' && typeof __args[1] === 'function') {
+      j_testService["failingCall(java.lang.String,io.vertx.core.Handler)"](value, function(ar) {
+      if (ar.succeeded()) {
+        resultHandler(utils.convReturnJson(ar.result()), null);
       } else {
         resultHandler(null, ar.cause());
       }


### PR DESCRIPTION
Add a new ServiceException class that service implementations can
return to their callers via a MessageCodec, instead of only passing
the message contained in the exception to the caller.

Signed-off-by: Dan O'Reilly <oreilldf@gmail.com>