### PR TITLE
Proxy generator test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,13 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
@@ -154,6 +161,47 @@
             </additionalClasspathElements>
           </configuration>
         </plugin>
+        
+        <!--This plugin's configuration is used to store Eclipse m2e settings 
+		only. It has no influence on the Maven build itself. -->
+		<plugin>
+			<groupId>org.eclipse.m2e</groupId>
+			<artifactId>lifecycle-mapping</artifactId>
+			<version>1.0.0</version>
+			<configuration>
+				<lifecycleMappingMetadata>
+					<pluginExecutions>
+						<pluginExecution>
+							<pluginExecutionFilter>
+								<groupId>org.codehaus.mojo</groupId>
+								<artifactId>buildhelper-maven-plugin</artifactId>
+								<versionRange>[1.8,)</versionRange>
+								<goals>
+									<goal>add-test-source</goal>
+								</goals>
+							</pluginExecutionFilter>
+							<action>
+								<execute />
+							</action>
+						</pluginExecution>
+						<pluginExecution>
+							<pluginExecutionFilter>
+								<groupId>org.apache.maven.plugins</groupId>
+								<artifactId>maven-dependency-plugin</artifactId>
+								<versionRange>[2.10,)</versionRange>
+								<goals>
+									<goal>copy</goal>
+									<goal>properties</goal>
+								</goals>
+							</pluginExecutionFilter>
+							<action>
+								<execute />
+							</action>
+						</pluginExecution>
+					</pluginExecutions>
+				</lifecycleMappingMetadata>
+			</configuration>
+		</plugin>
 
       </plugins>
 
@@ -279,6 +327,24 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+		<groupId>org.codehaus.mojo</groupId>
+		  <artifactId>build-helper-maven-plugin</artifactId>
+		  <executions>
+		     <execution>
+		        <id>add-test-source</id>
+		        <phase>generate-test-sources</phase>
+		        <goals>
+		           <goal>add-test-source</goal>
+		        </goals>
+		        <configuration>
+		          <sources>
+		            <source>${project.build.directory}/generated-test-sources/tests-annotations/</source>
+		          </sources>
+		        </configuration>
+		     </execution>
+		  </executions>
       </plugin>
     </plugins>
   </build>

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -25,7 +25,7 @@ your build descriptor:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-proxy</artifactId>
-  <version>3.6.0.CR1</version>
+  <version>3.6.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -33,7 +33,7 @@ your build descriptor:
 
 [source,groovy,subs="+attributes"]
 ----
-compile 'io.vertx:vertx-service-proxy:3.6.0.CR1'
+compile 'io.vertx:vertx-service-proxy:3.6.0-SNAPSHOT'
 ----
 
 To *implement* service proxies, also add:
@@ -45,7 +45,7 @@ To *implement* service proxies, also add:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-codegen</artifactId>
-  <version>3.6.0.CR1</version>
+  <version>3.6.0-SNAPSHOT</version>
   <scope>provided</scope>
 </dependency>
 ----
@@ -54,7 +54,7 @@ To *implement* service proxies, also add:
 
 [source,groovy,subs="+attributes"]
 ----
-compileOnly 'io.vertx:vertx-codegen:3.6.0.CR1'
+compileOnly 'io.vertx:vertx-codegen:3.6.0-SNAPSHOT'
 ----
 
 Be aware that as the service proxy mechanism relies on code generation, so modifications to the _service interface_
@@ -231,7 +231,7 @@ Here a configuration example for Maven:
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-service-proxy</artifactId>
-  <version>3.6.0.CR1</version>
+  <version>3.6.0-SNAPSHOT</version>
   <classifier>processor</classifier>
 </dependency>
 ----
@@ -240,7 +240,7 @@ This feature can also be used in Gradle:
 
 [source]
 ----
-compile "io.vertx:vertx-service-proxy:3.6.0.CR1:processor"
+compile "io.vertx:vertx-service-proxy:3.6.0-SNAPSHOT:processor"
 ----
 
 IDE provides usually support for annotation processors.

--- a/src/test/java/io/vertx/serviceproxy/service/user/ServiceProxyGeneratorTest.java
+++ b/src/test/java/io/vertx/serviceproxy/service/user/ServiceProxyGeneratorTest.java
@@ -1,0 +1,137 @@
+package io.vertx.serviceproxy.service.user;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.serviceproxy.ServiceBinder;
+
+@RunWith(VertxUnitRunner.class)
+public class ServiceProxyGeneratorTest 
+{
+	private static Vertx vertx;
+	
+	private static AbstractVerticle verticle;
+	
+	private static final Collection<MessageConsumer<JsonObject>> serviceConsumers = new ArrayList<>(); 
+	
+	private static ServiceBinder serviceBinder;
+	
+	@BeforeClass
+	public static void setUp(final TestContext testContext) 
+	{
+        VertxOptions options = new VertxOptions();
+ 		if (java.lang.management.ManagementFactory.getRuntimeMXBean().
+ 			    getInputArguments().toString().indexOf("-agentlib:jdwp") > 0)
+ 		{
+ 			options.setBlockedThreadCheckInterval(1_000_000L);
+ 		}
+        vertx = Vertx.vertx(options);
+        
+        verticle = new AbstractVerticle()
+        {
+        	@Override
+        	public void start(final Future<Void> startFuture) throws Exception 
+        	{
+        		final UserDao currUserDao = UserDao.create(this.vertx, new JsonObject());
+        		serviceBinder = new ServiceBinder(vertx);
+        		
+        		serviceConsumers.add(serviceBinder
+        			.setAddress(UserDao.SERVICE_ADDRESS)
+        			.register(UserDao.class, currUserDao)
+        		);
+        		
+        		startFuture.complete();
+        	}
+        };
+        
+        Thread.currentThread().setName("JUNIT");
+        final Async async = testContext.async();
+        
+        vertx.deployVerticle(verticle, new Handler<AsyncResult<String>>()
+		{
+			@Override
+			public void handle(AsyncResult<String> deployVerticleEvent) 
+			{
+				if (deployVerticleEvent.succeeded())
+				{
+					async.complete();
+				}
+				else
+				{
+					testContext.fail(deployVerticleEvent.cause());
+					async.complete();
+				}
+			}
+		});
+	}
+	
+	
+	@AfterClass
+	public static void tearDown(final TestContext testContext) throws Exception
+	{
+		if (serviceBinder != null)
+		{
+			for(MessageConsumer<JsonObject> serviceConsumer : serviceConsumers)
+			{
+				serviceBinder.unregister(serviceConsumer);
+			}
+		}
+			
+		if (verticle != null)
+		{
+			verticle.stop();
+		}
+	}
+	
+	
+	
+	
+	@Test
+	public void testGenerator(TestContext testContext) throws Exception
+	{
+		final Async async = testContext.async();
+		final UserDao daoProxy = UserDao.createProxy(vertx, UserDao.SERVICE_ADDRESS);
+		daoProxy.findAll(new Handler<AsyncResult<List<JsonObject>>>() 
+		{
+			@Override
+			public void handle(AsyncResult<List<JsonObject>> event) 
+			{
+				if (event.succeeded())
+				{
+					testContext.verify(new Handler<Void>() {
+						@Override
+						public void handle(Void verifyEvent) 
+						{
+							assertThat(event.result()).hasSize(2);
+							async.complete();
+						}
+					});
+				}
+				else
+				{
+					testContext.fail(event.cause());
+					async.complete();
+				}
+				
+			}
+		});
+	}
+}

--- a/src/test/java/io/vertx/serviceproxy/service/user/User.java
+++ b/src/test/java/io/vertx/serviceproxy/service/user/User.java
@@ -1,0 +1,65 @@
+package io.vertx.serviceproxy.service.user;
+
+import java.io.Serializable;
+
+/**
+ * User of the application.
+ */
+public class User implements Serializable 
+{
+	private static final long serialVersionUID = 1L;
+	
+	private String id;
+	
+	private String familyName;
+
+	private String givenName;
+	
+	private String email;
+	
+	public String getId() 
+	{
+		return id;
+	}
+
+	public void setId(String id) 
+	{
+		this.id = id;
+	}
+
+	public String getFamilyName()
+	{
+		return familyName;
+	}
+
+	public void setFamilyName(String familyName)
+	{
+		this.familyName = familyName;
+	}
+
+	public String getGivenName()
+	{
+		return givenName;
+	}
+
+	public void setGivenName(String givenName)
+	{
+		this.givenName = givenName;
+	}
+	
+	public String getEmail()
+	{
+		return email;
+	}
+
+	public void setEmail(final String email)
+	{
+		this.email = email;
+	}
+
+	@Override
+	public String toString() 
+	{
+		return "User [id=" + id + ", familyName=" + familyName + ", givenName=" + givenName + ", email=" + email + "]";
+	}
+}

--- a/src/test/java/io/vertx/serviceproxy/service/user/UserDao.java
+++ b/src/test/java/io/vertx/serviceproxy/service/user/UserDao.java
@@ -1,0 +1,31 @@
+package io.vertx.serviceproxy.service.user;
+
+import java.util.List;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.codegen.annotations.ProxyIgnore;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+
+@ProxyGen
+public interface UserDao
+{
+	static final String SERVICE_ADDRESS = "dao.user";
+	
+	static UserDao create(Vertx vertx, JsonObject config) 
+	{
+		return new UserDaoImpl(vertx, config);
+	}
+
+	static UserDao createProxy(Vertx vertx, String address) 
+	{
+		return new UserDaoVertxEBProxy(vertx, address);
+	}
+	
+	void findAll(Handler<AsyncResult<List<JsonObject>>> result);
+	
+	@ProxyIgnore
+	void close();
+}

--- a/src/test/java/io/vertx/serviceproxy/service/user/UserDaoImpl.java
+++ b/src/test/java/io/vertx/serviceproxy/service/user/UserDaoImpl.java
@@ -1,0 +1,83 @@
+package io.vertx.serviceproxy.service.user;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.ServiceException;
+
+public class UserDaoImpl implements UserDao, Serializable
+{
+	private static final long serialVersionUID = 1L;
+	
+	private final JsonObject config;
+
+	/**
+	 * Implementation du service W2UserDao.
+	 * 
+	 * @param vertx référence vers le verticle DAO.
+	 * @param config configuration de l'accès à la base de données MongoDB.
+	 */
+	public UserDaoImpl(final Vertx vertx, final JsonObject config)
+	{
+		this.config = config;
+	}
+	
+	@Override
+	public void findAll(final Handler<AsyncResult<List<JsonObject>>> result) 
+	{
+		try
+		{
+			final List<JsonObject> results = new ArrayList<>();
+			
+			final User julienPongeUser = new User();
+			julienPongeUser.setFamilyName("PONGE");
+			julienPongeUser.setGivenName("Julien");
+			julienPongeUser.setEmail("julien@ponge.org");
+			
+			final User julienVietUser = new User();
+			julienVietUser.setFamilyName("VIET");
+			julienVietUser.setGivenName("Julien");
+			julienVietUser.setEmail("julien@julienviet.com");
+			
+			results.add(serializeToJson(julienPongeUser));
+			results.add(serializeToJson(julienVietUser));
+			
+			result.handle(Future.succeededFuture(results));
+		}
+		catch (VertxException ve)
+		{
+			result.handle(ServiceException.fail(400, ve.getMessage()));
+		}
+	}
+	
+	@Override
+	public void close() 
+	{
+		// do nothing
+	}
+	
+	
+	
+	private JsonObject serializeToJson(User user) 
+	{
+		final JsonObject json = new JsonObject();
+		
+		json.put("familyName", user.getFamilyName());
+		json.put("givenName", user.getGivenName());
+		json.put("email", user.getEmail());
+		
+		if (user.getId() != null && !"".equals(user.getId()))
+		{
+			json.put("_id", user.getId());
+		}
+		
+		return json;
+	}
+}

--- a/src/test/java/io/vertx/serviceproxy/service/user/package-info.java
+++ b/src/test/java/io/vertx/serviceproxy/service/user/package-info.java
@@ -1,0 +1,5 @@
+@ModuleGen(name = "user-dao", groupPackage = "io.vertx.serviceproxy.service.user")
+
+package io.vertx.serviceproxy.service.user;
+
+import io.vertx.codegen.annotations.ModuleGen;


### PR DESCRIPTION
Hello @vietj, @jponge, 

As requested, I will come to create a new pull request to test the service proxy generation with vertx 3.6.0-SNAPSHOT. **And, there is no issue, the proxy generation works very well !!!**

So, I don't understand why in my case, it doesn't work with vertx 3.6.0-SNAPSHOT while it works with vertx 3.4.2 ?? [PR #32 on vertx-sync module](https://github.com/vert-x3/vertx-sync/pull/32)

What is the difference ? In this PR, I don't use vertx-sync ?

You can close this pull request or merge to complete the code cover.

Thanks,
Fabien