### PR TITLE
Change enum to json by a call to name() instead of toString()

### DIFF
--- a/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyGen.java
+++ b/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyGen.java
@@ -148,7 +148,7 @@ public class ServiceProxyGen extends Generator<ProxyModel> {
     else if ("java.lang.Character".equals(t.getName()))
       writer.stmt("_json.put(\"" + name + "\", " + name + " == null ? null : (int)" + name + ")");
     else if (t.getKind() == ClassKind.ENUM)
-      writer.stmt("_json.put(\"" + name + "\", " + name + " == null ? null : " + name + ".toString())");
+      writer.stmt("_json.put(\"" + name + "\", " + name + " == null ? null : " + name + ".name())");
     else if (t.getKind() == ClassKind.LIST) {
       if (((ParameterizedTypeInfo)t).getArg(0).getKind() == ClassKind.DATA_OBJECT)
         writer.stmt("_json.put(\"" + name + "\", new JsonArray(" + name + " == null ? java.util.Collections.emptyList() : " + name + ".stream().map(r -> r == null ? null : r.toJson()).collect(Collectors.toList())))");


### PR DESCRIPTION
Fix proposal for https://github.com/vert-x3/issues/issues/445

`*ServiceVertxEBProxy` is generated with:

- `.valueOf()` to marshall from json msg
- `.toString()` to unmarshall to json msg

If `.toString()` is overwritten, we are losing the symmetry. So change it by `name()`.

