### PR TITLE
ServiceException debugInfo is filled with cause

### DIFF
--- a/src/main/java/io/vertx/serviceproxy/ServiceBinder.java
+++ b/src/main/java/io/vertx/serviceproxy/ServiceBinder.java
@@ -16,11 +16,9 @@
 package io.vertx.serviceproxy;
 
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.eventbus.MessageConsumer;
-import io.vertx.core.eventbus.ReplyException;
 import io.vertx.core.json.JsonObject;
 
 import java.lang.reflect.Constructor;
@@ -42,6 +40,7 @@ public class ServiceBinder {
   private boolean topLevel = true;
   private long timeoutSeconds = DEFAULT_CONNECTION_TIMEOUT;
   private List<Function<Message<JsonObject>, Future<Message<JsonObject>>>> interceptors;
+  private boolean includeDebugInfo = false;
 
   /**
    * Creates a factory.
@@ -84,6 +83,18 @@ public class ServiceBinder {
    */
   public ServiceBinder setTimeoutSeconds(long timeoutSeconds) {
     this.timeoutSeconds = timeoutSeconds;
+    return this;
+  }
+
+  /**
+   * When an exception is thrown by the service or the underlying handler, include
+   * debugging info in the ServiceException, that you can access with {@link ServiceException#getDebugInfo()}
+   *
+   * @param includeDebugInfo
+   * @return self
+   */
+  public ServiceBinder setIncludeDebugInfo(boolean includeDebugInfo) {
+    this.includeDebugInfo = includeDebugInfo;
     return this;
   }
 
@@ -143,8 +154,8 @@ public class ServiceBinder {
   private <T> ProxyHandler getProxyHandler(Class<T> clazz, T service) {
     String handlerClassName = clazz.getName() + "VertxProxyHandler";
     Class<?> handlerClass = loadClass(handlerClassName, clazz);
-    Constructor constructor = getConstructor(handlerClass, Vertx.class, clazz, boolean.class, long.class);
-    Object instance = createInstance(constructor, vertx, service, topLevel, timeoutSeconds);
+    Constructor constructor = getConstructor(handlerClass, Vertx.class, clazz, boolean.class, long.class, boolean.class);
+    Object instance = createInstance(constructor, vertx, service, topLevel, timeoutSeconds, includeDebugInfo);
     return (ProxyHandler) instance;
   }
 

--- a/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyHandlerGen.java
+++ b/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyHandlerGen.java
@@ -90,6 +90,7 @@ public class ServiceProxyHandlerGen extends Generator<ProxyModel> {
       .stmt("private final long timerID")
       .stmt("private long lastAccessed")
       .stmt("private final long timeoutSeconds")
+      .stmt("private final boolean includeDebugInfo")
       .newLine()
       .code("public " + className + "(Vertx vertx, " + model.getIfaceSimpleName() + " service){\n")
       .indent()
@@ -103,7 +104,13 @@ public class ServiceProxyHandlerGen extends Generator<ProxyModel> {
       .unindent()
       .code("}\n")
       .newLine()
-      .code("public " + className + "(Vertx vertx, " + model.getIfaceSimpleName() + " service, boolean topLevel, long timeoutSeconds) {\n");
+      .code("public "+ className + "(Vertx vertx, " + model.getIfaceSimpleName() + " service, boolean topLevel, long timeoutInSecond){\n")
+      .indent()
+      .stmt("this(vertx, service, true, timeoutInSecond, false)")
+      .unindent()
+      .code("}\n")
+      .newLine()
+      .code("public " + className + "(Vertx vertx, " + model.getIfaceSimpleName() + " service, boolean topLevel, long timeoutSeconds, boolean includeDebugInfo) {\n");
     utils.handlerConstructorBody(writer);
     writer.code("private void checkTimedOut(long id) {\n")
       .indent()
@@ -142,7 +149,8 @@ public class ServiceProxyHandlerGen extends Generator<ProxyModel> {
       .unindent()
       .code("} catch (Throwable t) {\n")
       .indent()
-      .stmt("msg.reply(new ServiceException(500, t.getMessage()))")
+      .stmt("if (includeDebugInfo) msg.reply(new ServiceException(500, t.getMessage(), HelperUtils.generateDebugInfo(t)))")
+      .stmt("else msg.reply(new ServiceException(500, t.getMessage()))")
       .stmt("throw t")
       .unindent()
       .code("}\n")
@@ -228,29 +236,21 @@ public class ServiceProxyHandlerGen extends Generator<ProxyModel> {
       String coll = typeArg.getKind() == ClassKind.LIST ? "List" : "Set";
       TypeInfo innerTypeArg = ((ParameterizedTypeInfo)typeArg).getArg(0);
       if (innerTypeArg.getName().equals("java.lang.Character"))
-        return "HelperUtils.create" + coll + "CharHandler(msg)";
+        return "HelperUtils.create" + coll + "CharHandler(msg, includeDebugInfo)";
       if (innerTypeArg.getKind() == ClassKind.DATA_OBJECT)
         return "res -> {\n" +
           "            if (res.failed()) {\n" +
-          "              if (res.cause() instanceof ServiceException) {\n" +
-          "                msg.reply(res.cause());\n" +
-          "              } else {\n" +
-          "                msg.reply(new ServiceException(-1, res.cause().getMessage()));\n" +
-          "              }\n" +
+          "              HelperUtils.manageFailure(msg, res.cause(), includeDebugInfo);\n" +
           "            } else {\n" +
           "              msg.reply(new JsonArray(res.result().stream().map(r -> r == null ? null : r.toJson()).collect(Collectors.toList())));\n" +
           "            }\n" +
           "         }";
-      return "HelperUtils.create" + coll + "Handler(msg)";
+      return "HelperUtils.create" + coll + "Handler(msg, includeDebugInfo)";
     }
     if (typeArg.getKind() == ClassKind.DATA_OBJECT)
       return "res -> {\n" +
         "            if (res.failed()) {\n" +
-        "              if (res.cause() instanceof ServiceException) {\n" +
-        "                msg.reply(res.cause());\n" +
-        "              } else {\n" +
-        "                msg.reply(new ServiceException(-1, res.cause().getMessage()));\n" +
-        "              }\n" +
+        "              HelperUtils.manageFailure(msg, res.cause(), includeDebugInfo);\n" +
         "            } else {\n" +
         "              msg.reply(res.result() == null ? null : res.result().toJson());\n" +
         "            }\n" +
@@ -258,18 +258,14 @@ public class ServiceProxyHandlerGen extends Generator<ProxyModel> {
     if (typeArg.getKind() == ClassKind.API && ((ApiTypeInfo)typeArg).isProxyGen())
       return "res -> {\n" +
         "            if (res.failed()) {\n" +
-        "                if (res.cause() instanceof ServiceException) {\n" +
-        "                  msg.reply(res.cause());\n" +
-        "                } else {\n" +
-        "                  msg.reply(new ServiceException(-1, res.cause().getMessage()));\n" +
-        "                }\n" +
+        "              HelperUtils.manageFailure(msg, res.cause(), includeDebugInfo);\n" +
         "            } else {\n" +
         "              String proxyAddress = UUID.randomUUID().toString();\n" +
         "              ProxyHelper.registerService(" + typeArg.getSimpleName() + ".class, vertx, res.result(), proxyAddress, false, timeoutSeconds);\n" +
         "              msg.reply(null, new DeliveryOptions().addHeader(\"proxyaddr\", proxyAddress));\n" +
         "            }\n" +
         "          }";
-    return "HelperUtils.createHandler(msg)";
+    return "HelperUtils.createHandler(msg, includeDebugInfo)";
   }
 
 }

--- a/src/main/resources/META-INF/vertx/vertx-service-proxy/handler_constructor_body.txt
+++ b/src/main/resources/META-INF/vertx/vertx-service-proxy/handler_constructor_body.txt
@@ -1,5 +1,6 @@
     this.vertx = vertx;
     this.service = service;
+    this.includeDebugInfo = includeDebugInfo;
     this.timeoutSeconds = timeoutSeconds;
     try {
       this.vertx.eventBus().registerDefaultCodec(ServiceException.class,

--- a/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
+++ b/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
@@ -52,12 +52,13 @@ import io.vertx.test.core.VertxTestBase;
 public class ServiceProxyTest extends VertxTestBase {
 
   public final static String SERVICE_ADDRESS = "someaddress";
+  public final static String SERVICE_WITH_DEBUG_ADDRESS = "someaddressdebug";
   public final static String SERVICE_LOCAL_ADDRESS = "someaddress.local";
   public final static String TEST_ADDRESS = "testaddress";
 
-  MessageConsumer<JsonObject> consumer, localConsumer;
+  MessageConsumer<JsonObject> consumer, localConsumer, consumerWithDebugEnabled;
   TestService service, localService;
-  TestService proxy, localProxy;
+  TestService proxy, localProxy, proxyWithDebug;
 
   @Override
   public void setUp() throws Exception {
@@ -67,11 +68,16 @@ public class ServiceProxyTest extends VertxTestBase {
     
     consumer = new ServiceBinder(vertx).setAddress(SERVICE_ADDRESS)
       .register(TestService.class, service);
+    consumerWithDebugEnabled = new ServiceBinder(vertx)
+      .setAddress(SERVICE_WITH_DEBUG_ADDRESS)
+      .setIncludeDebugInfo(true)
+      .register(TestService.class, service);
     localConsumer = new ServiceBinder(vertx).setAddress(SERVICE_LOCAL_ADDRESS)
       .registerLocal(TestService.class, localService);
 
     proxy = TestService.createProxy(vertx, SERVICE_ADDRESS);
     localProxy = TestService.createProxy(vertx, SERVICE_LOCAL_ADDRESS);
+    proxyWithDebug = TestService.createProxy(vertx, SERVICE_WITH_DEBUG_ADDRESS);
     vertx.eventBus().<String>consumer(TEST_ADDRESS).handler(msg -> {
       assertEquals("ok", msg.body());
       testComplete();
@@ -110,6 +116,20 @@ public class ServiceProxyTest extends VertxTestBase {
     });
     await();
 
+  }
+
+  @Test
+  public void testCauseErrorHandling() {
+    proxyWithDebug.failingCall("Fail with cause", handler -> {
+      assertTrue(handler.cause() instanceof ServiceException);
+      ServiceException cause = (ServiceException) handler.cause();
+      assertEquals("Failed!", handler.cause().getMessage());
+      assertEquals(IllegalArgumentException.class.getCanonicalName(), cause.getDebugInfo().getString("causeName"));
+      assertEquals("Failed!", cause.getDebugInfo().getString("causeMessage"));
+      assertFalse(cause.getDebugInfo().getJsonArray("causeStackTrace").isEmpty());
+      testComplete();
+    });
+    await();
   }
 
   @Test
@@ -547,9 +567,10 @@ public class ServiceProxyTest extends VertxTestBase {
   public void testFailingMethod() {
     proxy.failingMethod(onFailure(t -> {
       assertTrue(t instanceof ReplyException);
-      ReplyException re = (ReplyException) t;
-      assertEquals(ReplyFailure.RECIPIENT_FAILURE, re.failureType());
-      assertEquals("wibble", re.getMessage());
+      ServiceException se = (ServiceException) t;
+      assertEquals(ReplyFailure.RECIPIENT_FAILURE, se.failureType());
+      assertEquals("wibble", se.getMessage());
+      assertTrue(se.getDebugInfo().isEmpty());
       testComplete();
     }));
     await();
@@ -576,11 +597,12 @@ public class ServiceProxyTest extends VertxTestBase {
     message.put("object", new JsonObject().put("foo", "bar"));
     message.put("str", "blah");
     message.put("i", 1234);
-    vertx.eventBus().send("someaddress", message, new DeliveryOptions().addHeader("action", "yourmum").setSendTimeout(500), onFailure(t -> {
-      assertTrue(t instanceof ReplyException);
-      ReplyException re = (ReplyException) t;
+    vertx.eventBus().send(SERVICE_WITH_DEBUG_ADDRESS, message, new DeliveryOptions().addHeader("action", "yourmum").setSendTimeout(500), onFailure(t -> {
+      assertTrue(t instanceof ServiceException);
+      ServiceException se = (ServiceException) t;
       // This will as operation will fail to be invoked
-      assertEquals(ReplyFailure.RECIPIENT_FAILURE, re.failureType());
+      assertEquals(ReplyFailure.RECIPIENT_FAILURE, se.failureType());
+      assertEquals(IllegalStateException.class.getCanonicalName(), se.getDebugInfo().getString("causeName"));
       testComplete();
     }));
     await();
@@ -590,15 +612,17 @@ public class ServiceProxyTest extends VertxTestBase {
   public void testCallWithMessageParamWrongType() {
     JsonObject message = new JsonObject();
     message.put("object", new JsonObject().put("foo", "bar"));
-    message.put("str", 76523);
+    message.put("str", 76523); // <- wrong one
     message.put("i", 1234);
     message.put("char", (int)'X'); // chars are mapped to ints
     message.put("enum", SomeEnum.BAR.toString()); // enums are mapped to strings
-    vertx.eventBus().send("someaddress", message, new DeliveryOptions().addHeader("action", "invokeWithMessage").setSendTimeout(500), onFailure(t -> {
-      assertTrue(t instanceof ReplyException);
-      ReplyException re = (ReplyException) t;
+    vertx.eventBus().send(SERVICE_WITH_DEBUG_ADDRESS, message, new DeliveryOptions().addHeader("action", "invokeWithMessage").setSendTimeout(500), onFailure(t -> {
+      assertTrue(t instanceof ServiceException);
+      ServiceException se = (ServiceException) t;
       // This will as operation will fail to be invoked
-      assertEquals(ReplyFailure.RECIPIENT_FAILURE, re.failureType());
+      assertEquals(ReplyFailure.RECIPIENT_FAILURE, se.failureType());
+      assertEquals(ClassCastException.class.getCanonicalName(), se.getDebugInfo().getString("causeName"));
+      assertFalse(se.getDebugInfo().getJsonArray("causeStackTrace").isEmpty());
       testComplete();
     }));
     await();

--- a/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestServiceImpl.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestServiceImpl.java
@@ -589,6 +589,8 @@ public class TestServiceImpl implements TestService {
       resultHandler.handle(ServiceException.fail(25, "Call has failed", new JsonObject().put("test", "val")));
     } else if (value.equals("Fail subclass")) {
       resultHandler.handle(MyServiceException.fail(25, "Call has failed", "some extra"));
+    } else if (value.equals("Fail with cause")) {
+      resultHandler.handle(Future.failedFuture(new IllegalArgumentException("Failed!").fillInStackTrace()));
     } else {
       resultHandler.handle(Future.succeededFuture(new JsonObject()));
     }


### PR DESCRIPTION
When an exception is thrown by the service or the underlying handler, include the debugging info in the `ServiceException`, that you can access using `ServiceException.getDebugInfo()`. The included info are the canonical name of the exception, the message and the stacktrace
Fixes #88 