### PR TITLE
Supporting Future<T> methods for 4.0

### DIFF
--- a/src/main/java/io/vertx/serviceproxy/HelperUtils.java
+++ b/src/main/java/io/vertx/serviceproxy/HelperUtils.java
@@ -1,6 +1,8 @@
 package io.vertx.serviceproxy;
 
+import io.vertx.codegen.type.TypeInfo;
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
@@ -141,4 +143,7 @@ public class HelperUtils {
       .collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
   }
 
+  public static boolean isFuture(TypeInfo type) {
+    return type.isParameterized() && Future.class.getName().equals(type.getRaw().getName());
+  }
 }

--- a/src/main/java/io/vertx/serviceproxy/HelperUtils.java
+++ b/src/main/java/io/vertx/serviceproxy/HelperUtils.java
@@ -1,15 +1,12 @@
 package io.vertx.serviceproxy;
 
-import io.vertx.codegen.type.TypeInfo;
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.eventbus.Message;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author <a href="http://slinkydeveloper.github.io">Francesco Guardiani @slinkydeveloper</a>
@@ -143,7 +140,4 @@ public class HelperUtils {
       .collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
   }
 
-  public static boolean isFuture(TypeInfo type) {
-    return type.isParameterized() && Future.class.getName().equals(type.getRaw().getName());
-  }
 }

--- a/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyGen.java
+++ b/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyGen.java
@@ -6,14 +6,12 @@ import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.type.*;
 import io.vertx.codegen.writer.CodeWriter;
 import io.vertx.core.Promise;
-import io.vertx.serviceproxy.HelperUtils;
 import io.vertx.serviceproxy.generator.model.ProxyMethodInfo;
 import io.vertx.serviceproxy.generator.model.ProxyModel;
 
 import java.io.StringWriter;
 import java.lang.annotation.Annotation;
 import java.util.*;
-import java.util.stream.Collectors;
 
 /**
  * @author <a href="http://slinkydeveloper.github.io">Francesco Guardiani @slinkydeveloper</a>
@@ -50,7 +48,7 @@ public class ServiceProxyGen extends Generator<ProxyModel> {
     writer.code("\n");
     utils.proxyGenImports(writer);
     utils.additionalImports(model).forEach(i -> utils.writeImport(writer, i));
-    boolean importPromise = model.getMethods().stream().anyMatch(m -> !m.isStaticMethod() && HelperUtils.isFuture(m.getReturnType()));
+    boolean importPromise = model.getMethods().stream().anyMatch(m -> !m.isStaticMethod() && ProxyModel.isFuture(m.getReturnType()));
     if (importPromise) {
       utils.writeImport(writer, Promise.class.getName());
     }
@@ -116,7 +114,7 @@ public class ServiceProxyGen extends Generator<ProxyModel> {
     ParamInfo lastParam = !method.getParams().isEmpty() ? method.getParam(method.getParams().size() - 1) : null;
     boolean hasResultHandler = utils.isResultHandler(lastParam);
     TypeInfo returnType = method.getReturnType();
-    boolean returnFuture = HelperUtils.isFuture(returnType);
+    boolean returnFuture = ProxyModel.isFuture(returnType);
     if (hasResultHandler || returnFuture) {
       writer.code("if (closed) {\n");
       writer.indent();

--- a/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyHandlerGen.java
+++ b/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyHandlerGen.java
@@ -6,7 +6,6 @@ import io.vertx.codegen.annotations.ModuleGen;
 import io.vertx.codegen.annotations.ProxyGen;
 import io.vertx.codegen.type.*;
 import io.vertx.codegen.writer.CodeWriter;
-import io.vertx.serviceproxy.HelperUtils;
 import io.vertx.serviceproxy.generator.model.ProxyMethodInfo;
 import io.vertx.serviceproxy.generator.model.ProxyModel;
 
@@ -161,7 +160,7 @@ public class ServiceProxyHandlerGen extends Generator<ProxyModel> {
     ParamInfo lastParam = !m.getParams().isEmpty() ? m.getParam(m.getParams().size() - 1) : null;
     boolean hasResultHandler = utils.isResultHandler(lastParam);
     TypeInfo returnType = m.getReturnType();
-    boolean returnFuture = HelperUtils.isFuture(returnType);
+    boolean returnFuture = ProxyModel.isFuture(returnType);
     writer
       .code("case \"" + m.getName() + "\": {\n")
       .indent()

--- a/src/main/java/io/vertx/serviceproxy/generator/model/ProxyModel.java
+++ b/src/main/java/io/vertx/serviceproxy/generator/model/ProxyModel.java
@@ -22,7 +22,7 @@ import io.vertx.codegen.annotations.ProxyIgnore;
 import io.vertx.codegen.doc.Doc;
 import io.vertx.codegen.doc.Text;
 import io.vertx.codegen.type.*;
-import io.vertx.serviceproxy.HelperUtils;
+import io.vertx.core.Future;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
@@ -94,7 +94,7 @@ public class ProxyModel extends ClassModel {
     if (type.isVoid()) {
       return;
     }
-    if (HelperUtils.isFuture(type)) {
+    if (isFuture(type)) {
       ParameterizedTypeInfo parameterizedTypeInfo = (ParameterizedTypeInfo) type;
       TypeInfo arg = parameterizedTypeInfo.getArg(0);
       if (isLegalAsyncResultType(arg)) {
@@ -188,5 +188,9 @@ public class ProxyModel extends ClassModel {
 
   protected boolean isValidDataObject(TypeInfo typeInfo) {
     return typeInfo.getKind() == ClassKind.DATA_OBJECT && ((DataObjectTypeInfo)typeInfo).isSerializable() && ((DataObjectTypeInfo)typeInfo).isDeserializable();
+  }
+
+  public static boolean isFuture(TypeInfo type) {
+    return type.isParameterized() && Future.class.getName().equals(type.getRaw().getName());
   }
 }

--- a/src/test/java/io/vertx/serviceproxy/testmodel/TestFutureService.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/TestFutureService.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.serviceproxy.testmodel;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.ServiceProxyBuilder;
+import io.vertx.serviceproxy.testmodel.impl.TestFutureServiceImpl;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author lalitrao
+ */
+@ProxyGen
+public interface TestFutureService {
+
+  static TestFutureService create(Vertx vertx, TestService service) {
+    return new TestFutureServiceImpl(vertx, service);
+  }
+
+  static TestFutureService createProxy(Vertx vertx, String address) {
+    return new ServiceProxyBuilder(vertx).setAddress(address).build(TestFutureService.class);
+  }
+
+  static TestFutureService createProxyLongDelivery(Vertx vertx, String address) {
+    DeliveryOptions options = new DeliveryOptions();
+    options.setSendTimeout(20 * 1000L);
+    return new ServiceProxyBuilder(vertx).setAddress(address).setOptions(options).build(TestFutureService.class);
+  }
+
+  Future<String> longDeliverySuccess();
+
+  Future<String> longDeliveryFailed();
+
+  Future<TestConnection> createConnection(String str);
+
+  Future<TestConnectionWithCloseFuture> createConnectionWithCloseFuture();
+
+  Future<SomeEnum> enumTypeAsResult();
+
+  Future<SomeEnum> enumTypeAsResultNull();
+
+  Future<String> stringFuture();
+
+  Future<String> stringNullFuture();
+
+  Future<Byte> byteFuture();
+
+  Future<Byte> byteNullFuture();
+
+  Future<Short> shortFuture();
+
+  Future<Short> shortNullFuture();
+
+  Future<Integer> intFuture();
+
+  Future<Integer> intNullFuture();
+
+  Future<Long> longFuture();
+
+  Future<Long> longNullFuture();
+
+  Future<Float> floatFuture();
+
+  Future<Float> floatNullFuture();
+
+  Future<Double> doubleFuture();
+
+  Future<Double> doubleNullFuture();
+
+  Future<Character> charFuture();
+
+  Future<Character> charNullFuture();
+
+  Future<Boolean> booleanFuture();
+
+  Future<Boolean> booleanNullFuture();
+
+  Future<JsonObject> jsonObjectFuture();
+
+  Future<JsonObject> jsonObjectNullFuture();
+
+  Future<JsonArray> jsonArrayFuture();
+
+  Future<JsonArray> jsonArrayNullFuture();
+
+  Future<TestDataObject> dataObjectFuture();
+
+  Future<TestDataObject> dataObjectNullFuture();
+
+  Future<Void> voidFuture();
+
+  Future<JsonObject> failingFuture();
+
+  Future<List<String>> listStringFuture();
+
+  Future<List<Byte>> listByteFuture();
+
+  Future<List<Short>> listShortFuture();
+
+  Future<List<Integer>> listIntFuture();
+
+  Future<List<Long>> listLongFuture();
+
+  Future<List<Float>> listFloatFuture();
+
+  Future<List<Double>> listDoubleFuture();
+
+  Future<List<Character>> listCharFuture();
+
+  Future<List<Boolean>> listBoolFuture();
+
+  Future<List<JsonObject>> listJsonObjectFuture();
+
+  Future<List<JsonArray>> listJsonArrayFuture();
+
+  Future<List<TestDataObject>> listDataObjectFuture();
+
+  Future<Set<String>> setStringFuture();
+
+  Future<Set<Byte>> setByteFuture();
+
+  Future<Set<Short>> setShortFuture();
+
+  Future<Set<Integer>> setIntFuture();
+
+  Future<Set<Long>> setLongFuture();
+
+  Future<Set<Float>> setFloatFuture();
+
+  Future<Set<Double>> setDoubleFuture();
+
+  Future<Set<Character>> setCharFuture();
+
+  Future<Set<Boolean>> setBoolFuture();
+
+  Future<Set<JsonObject>> setJsonObjectFuture();
+
+  Future<Set<JsonArray>> setJsonArrayFuture();
+
+  Future<Set<TestDataObject>> setDataObjectFuture();
+
+  Future<Map<String, String>> mapStringFuture();
+
+  Future<Map<String, Byte>> mapByteFuture();
+
+  Future<Map<String, Short>> mapShortFuture();
+
+  Future<Map<String, Integer>> mapIntFuture();
+
+  Future<Map<String, Long>> mapLongFuture();
+
+  Future<Map<String, Float>> mapFloatFuture();
+
+  Future<Map<String, Double>> mapDoubleFuture();
+
+  Future<Map<String, Character>> mapCharFuture();
+
+  Future<Map<String, Boolean>> mapBoolFuture();
+
+  Future<Map<String, JsonObject>> mapJsonObjectFuture();
+
+  Future<Map<String, JsonArray>> mapJsonArrayFuture();
+
+  Future<Map<String, TestDataObject>> mapDataObjectFuture();
+
+  Future<JsonObject> failingCall(String value);
+
+  Future<List<TestDataObject>> listDataObjectContainingNullFuture();
+
+  Future<Set<TestDataObject>> setDataObjectContainingNullFuture();
+
+  Future<ZonedDateTime> zonedDateTimeFuture();
+
+  Future<List<ZonedDateTime>> listZonedDateTimeFuture();
+
+  Future<Set<ZonedDateTime>> setZonedDateTimeFuture();
+
+  Future<Map<String, ZonedDateTime>> mapZonedDateTimeFuture();
+
+  Future<URI> uriFuture();
+
+  Future<List<URI>> listUriFuture();
+
+  Future<Set<URI>> setUriFuture();
+
+  Future<Map<String, URI>> mapUriFuture();
+
+}

--- a/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestFutureServiceImpl.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/impl/TestFutureServiceImpl.java
@@ -1,0 +1,593 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *  The Eclipse Public License is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  The Apache License v2.0 is available at
+ *  http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.serviceproxy.testmodel.impl;
+
+import io.vertx.core.*;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.serviceproxy.testmodel.*;
+
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.*;
+/**
+ * @author <a href="http://tfox.org">Tim Fox</a>
+ * @author lalitrao
+ */
+public class TestFutureServiceImpl implements TestFutureService {
+
+  private final Vertx vertx;
+  private TestService service;
+
+  public TestFutureServiceImpl(Vertx vertx, TestService service) {
+    this.vertx = vertx;
+    this.service = service;
+  }
+
+  @Override
+  public Future<TestConnection> createConnection(String str) {
+    Promise<TestConnection> promise = Promise.promise();
+    service.createConnection(str, promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<TestConnectionWithCloseFuture> createConnectionWithCloseFuture() {
+    Promise<TestConnectionWithCloseFuture> promise = Promise.promise();
+    service.createConnectionWithCloseFuture(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<SomeEnum> enumTypeAsResult() {
+    Promise<SomeEnum> promise = Promise.promise();
+    service.enumTypeAsResult(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<SomeEnum> enumTypeAsResultNull() {
+    Promise<SomeEnum> promise = Promise.promise();
+    service.enumTypeAsResultNull(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<String> stringFuture() {
+    Promise<String> promise = Promise.promise();
+    service.stringHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<String> stringNullFuture() {
+    Promise<String> promise = Promise.promise();
+    service.stringNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Byte> byteFuture() {
+    Promise<Byte> promise = Promise.promise();
+    service.byteHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Byte> byteNullFuture() {
+    Promise<Byte> promise = Promise.promise();
+    service.byteNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Short> shortFuture() {
+    Promise<Short> promise = Promise.promise();
+    service.shortHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Short> shortNullFuture() {
+    Promise<Short> promise = Promise.promise();
+    service.shortNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Integer> intFuture() {
+    Promise<Integer> promise = Promise.promise();
+    service.intHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Integer> intNullFuture() {
+    Promise<Integer> promise = Promise.promise();
+    service.intNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Long> longFuture() {
+    Promise<Long> promise = Promise.promise();
+    service.longHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Long> longNullFuture() {
+    Promise<Long> promise = Promise.promise();
+    service.longNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Float> floatFuture() {
+    Promise<Float> promise = Promise.promise();
+    service.floatHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Float> floatNullFuture() {
+    Promise<Float> promise = Promise.promise();
+    service.floatNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Double> doubleFuture() {
+    Promise<Double> promise = Promise.promise();
+    service.doubleHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Double> doubleNullFuture() {
+    Promise<Double> promise = Promise.promise();
+    service.doubleNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Character> charFuture() {
+    Promise<Character> promise = Promise.promise();
+    service.charHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Character> charNullFuture() {
+    Promise<Character> promise = Promise.promise();
+    service.charNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Boolean> booleanFuture() {
+    Promise<Boolean> promise = Promise.promise();
+    service.booleanHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Boolean> booleanNullFuture() {
+    Promise<Boolean> promise = Promise.promise();
+    service.booleanNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<JsonObject> jsonObjectFuture() {
+    Promise<JsonObject> promise = Promise.promise();
+    service.jsonObjectHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<JsonObject> jsonObjectNullFuture() {
+    Promise<JsonObject> promise = Promise.promise();
+    service.jsonObjectNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<JsonArray> jsonArrayFuture() {
+    Promise<JsonArray> promise = Promise.promise();
+    service.jsonArrayHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<JsonArray> jsonArrayNullFuture() {
+    Promise<JsonArray> promise = Promise.promise();
+    service.jsonArrayNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<TestDataObject> dataObjectFuture() {
+    Promise<TestDataObject> promise = Promise.promise();
+    service.dataObjectHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<TestDataObject> dataObjectNullFuture() {
+    Promise<TestDataObject> promise = Promise.promise();
+    service.dataObjectNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Void> voidFuture() {
+    Promise<Void> promise = Promise.promise();
+    service.voidHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<JsonObject> failingFuture() {
+    Promise<JsonObject> promise = Promise.promise();
+    service.failingMethod(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<String>> listStringFuture() {
+    Promise<List<String>> promise = Promise.promise();
+    service.listStringHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<Byte>> listByteFuture() {
+    Promise<List<Byte>> promise = Promise.promise();
+    service.listByteHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<Short>> listShortFuture() {
+    Promise<List<Short>> promise = Promise.promise();
+    service.listShortHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<Integer>> listIntFuture() {
+    Promise<List<Integer>> promise = Promise.promise();
+    service.listIntHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<Long>> listLongFuture() {
+    Promise<List<Long>> promise = Promise.promise();
+    service.listLongHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<Float>> listFloatFuture() {
+    Promise<List<Float>> promise = Promise.promise();
+    service.listFloatHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<Double>> listDoubleFuture() {
+    Promise<List<Double>> promise = Promise.promise();
+    service.listDoubleHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<Character>> listCharFuture() {
+    Promise<List<Character>> promise = Promise.promise();
+    service.listCharHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<Boolean>> listBoolFuture() {
+    Promise<List<Boolean>> promise = Promise.promise();
+    service.listBoolHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<JsonObject>> listJsonObjectFuture() {
+    Promise<List<JsonObject>> promise = Promise.promise();
+    service.listJsonObjectHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<JsonArray>> listJsonArrayFuture() {
+    Promise<List<JsonArray>> promise = Promise.promise();
+    service.listJsonArrayHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<String>> setStringFuture() {
+    Promise<Set<String>> promise = Promise.promise();
+    service.setStringHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<Byte>> setByteFuture() {
+    Promise<Set<Byte>> promise = Promise.promise();
+    service.setByteHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<Short>> setShortFuture() {
+    Promise<Set<Short>> promise = Promise.promise();
+    service.setShortHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<Integer>> setIntFuture() {
+    Promise<Set<Integer>> promise = Promise.promise();
+    service.setIntHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<Long>> setLongFuture() {
+    Promise<Set<Long>> promise = Promise.promise();
+    service.setLongHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<Float>> setFloatFuture() {
+    Promise<Set<Float>> promise = Promise.promise();
+    service.setFloatHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<Double>> setDoubleFuture() {
+    Promise<Set<Double>> promise = Promise.promise();
+    service.setDoubleHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<Character>> setCharFuture() {
+    Promise<Set<Character>> promise = Promise.promise();
+    service.setCharHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<Boolean>> setBoolFuture() {
+    Promise<Set<Boolean>> promise = Promise.promise();
+    service.setBoolHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<JsonObject>> setJsonObjectFuture() {
+    Promise<Set<JsonObject>> promise = Promise.promise();
+    service.setJsonObjectHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<JsonArray>> setJsonArrayFuture() {
+    Promise<Set<JsonArray>> promise = Promise.promise();
+    service.setJsonArrayHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<TestDataObject>> listDataObjectFuture() {
+    Promise<List<TestDataObject>> promise = Promise.promise();
+    service.listDataObjectHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<TestDataObject>> setDataObjectFuture() {
+    Promise<Set<TestDataObject>> promise = Promise.promise();
+    service.setDataObjectHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<String> longDeliverySuccess() {
+    Promise<String> promise = Promise.promise();
+    service.longDeliverySuccess(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<String> longDeliveryFailed() {
+    Promise<String> promise = Promise.promise();
+    service.longDeliveryFailed(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<JsonObject> failingCall(String value) {
+    Promise<JsonObject> promise = Promise.promise();
+    service.failingCall(value, promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<TestDataObject>> listDataObjectContainingNullFuture() {
+    Promise<List<TestDataObject>> promise = Promise.promise();
+    service.listDataObjectContainingNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<TestDataObject>> setDataObjectContainingNullFuture() {
+    Promise<Set<TestDataObject>> promise = Promise.promise();
+    service.setDataObjectContainingNullHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, String>> mapStringFuture() {
+    Promise<Map<String, String>> promise = Promise.promise();
+    service.mapStringHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, Byte>> mapByteFuture() {
+    Promise<Map<String, Byte>> promise = Promise.promise();
+    service.mapByteHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, Short>> mapShortFuture() {
+    Promise<Map<String, Short>> promise = Promise.promise();
+    service.mapShortHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, Integer>> mapIntFuture() {
+    Promise<Map<String, Integer>> promise = Promise.promise();
+    service.mapIntHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, Long>> mapLongFuture() {
+    Promise<Map<String, Long>> promise = Promise.promise();
+    service.mapLongHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, Float>> mapFloatFuture() {
+    Promise<Map<String, Float>> promise = Promise.promise();
+    service.mapFloatHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, Double>> mapDoubleFuture() {
+    Promise<Map<String, Double>> promise = Promise.promise();
+    service.mapDoubleHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, Character>> mapCharFuture() {
+    Promise<Map<String, Character>> promise = Promise.promise();
+    service.mapCharHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, Boolean>> mapBoolFuture() {
+    Promise<Map<String, Boolean>> promise = Promise.promise();
+    service.mapBoolHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, JsonObject>> mapJsonObjectFuture() {
+    Promise<Map<String, JsonObject>> promise = Promise.promise();
+    service.mapJsonObjectHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, JsonArray>> mapJsonArrayFuture() {
+    Promise<Map<String, JsonArray>> promise = Promise.promise();
+    service.mapJsonArrayHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, TestDataObject>> mapDataObjectFuture() {
+    Promise<Map<String, TestDataObject>> promise = Promise.promise();
+    service.mapDataObject(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<ZonedDateTime> zonedDateTimeFuture() {
+    Promise<ZonedDateTime> promise = Promise.promise();
+    service.zonedDateTimeHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<ZonedDateTime>> listZonedDateTimeFuture() {
+    Promise<List<ZonedDateTime>> promise = Promise.promise();
+    service.listZonedDateTimeHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<ZonedDateTime>> setZonedDateTimeFuture() {
+    Promise<Set<ZonedDateTime>> promise = Promise.promise();
+    service.setZonedDateTimeHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, ZonedDateTime>> mapZonedDateTimeFuture() {
+    Promise<Map<String, ZonedDateTime>> promise = Promise.promise();
+    service.mapZonedDateTimeHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<URI> uriFuture() {
+    Promise<URI> promise = Promise.promise();
+    service.uriHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<List<URI>> listUriFuture() {
+    Promise<List<URI>> promise = Promise.promise();
+    service.listUriHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Set<URI>> setUriFuture() {
+    Promise<Set<URI>> promise = Promise.promise();
+    service.setUriHandler(promise);
+    return promise.future();
+  }
+
+  @Override
+  public Future<Map<String, URI>> mapUriFuture() {
+    Promise<Map<String, URI>> promise = Promise.promise();
+    service.mapUriHandler(promise);
+    return promise.future();
+  }
+}


### PR DESCRIPTION
1, `ProxyModel.check ReturnType` allows to return the value of the `Future` type, Future's generic type is consistent with the AsyncResult's generic detection.
2, generate a method to return `Future` in `*VertxEBProxy` and `*VertxProxyHandler`
3, unit test
fix #107