### PR TITLE
Remove processor jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,24 +160,6 @@
         </executions>
       </plugin>
       <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>processor-jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-            <configuration>
-              <classifier>processor</classifier>
-              <excludes>
-                <exclude>examples/**</exclude>
-              </excludes>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
Followup of #121. Since we don't ship an annotation processor anymore, we don't need the annotation processor jar

Signed-off-by: Francesco Guardiani <francescoguard@gmail.com>
