### PR TITLE
Ensure stable 'action' header in delivery options

### DIFF
--- a/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyGen.java
+++ b/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyGen.java
@@ -136,6 +136,7 @@ public class ServiceProxyGen extends Generator<ProxyModel> {
     writer.newLine();
     writer.stmt("DeliveryOptions _deliveryOptions = (_options != null) ? new DeliveryOptions(_options) : new DeliveryOptions()");
     writer.stmt("_deliveryOptions.addHeader(\"action\", \"" + method.getName() + "\")");
+    writer.stmt("_deliveryOptions.getHeaders().set(\"action\", \"" + method.getName() + "\")");
     if (method.getKind() == MethodKind.CALLBACK) {
       TypeInfo t = ((ParameterizedTypeInfo)((ParameterizedTypeInfo)lastParam.getType()).getArg(0)).getArg(0);
       generateSendCallWithResultHandler(t, lastParam.getName(), writer, false);

--- a/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
+++ b/src/test/java/io/vertx/serviceproxy/test/ServiceProxyTest.java
@@ -1261,6 +1261,36 @@ public class ServiceProxyTest extends VertxTestBase {
   }
 
   @Test
+  public void testWithInitialHeader1() {
+    DeliveryOptions options = new DeliveryOptions();
+    options.addHeader("any", "thing");
+    TestService p = TestService.createProxyWithOptions(vertx, SERVICE_ADDRESS, options);
+    p.jsonObjectNullHandler(onSuccess(json -> {
+      assertNull(json);
+    }));
+    p.jsonObjectHandler(onSuccess(json -> {
+      assertNotNull(json);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
+  public void testWithInitialHeader2() {
+    DeliveryOptions options = new DeliveryOptions();
+    options.addHeader("action", "failingMethod");
+    TestService p = TestService.createProxyWithOptions(vertx, SERVICE_ADDRESS, options);
+    p.jsonObjectNullHandler(onSuccess(json -> {
+      assertNull(json);
+    }));
+    p.jsonObjectHandler(onSuccess(json -> {
+      assertNotNull(json);
+      testComplete();
+    }));
+    await();
+  }
+
+  @Test
   public void testUnregisteringTheService() {
     proxy.booleanHandler(ar -> {
       consumer.unregister(ar1 -> {

--- a/src/test/java/io/vertx/serviceproxy/testmodel/TestService.java
+++ b/src/test/java/io/vertx/serviceproxy/testmodel/TestService.java
@@ -57,6 +57,10 @@ public interface TestService {
     return new ServiceProxyBuilder(vertx).setAddress(address).setOptions(options).build(TestService.class);
   }
 
+  static TestService createProxyWithOptions(Vertx vertx, String address, DeliveryOptions options) {
+    return new ServiceProxyBuilder(vertx).setAddress(address).setOptions(options).build(TestService.class);
+  }
+
   void longDeliverySuccess(Handler<AsyncResult<String>> resultHandler);
 
   void longDeliveryFailed(Handler<AsyncResult<String>> resultHandler);


### PR DESCRIPTION
**`headers` in DeliveryOptions is not deep copied (vertx 4.2.6 currently).**

If initial DeliveryOptions provided, calls in those service proxies share the same `header` instance, **making the `action` header grows at every invocation**:

https://github.com/vert-x3/vertx-service-proxy/blob/0bef443030919547e9f96bbc0b8d52e0d73a8683/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyGen.java#L137-L138

Besides, the generated remote handler uses only the first value of the `action` header:

https://github.com/vert-x3/vertx-service-proxy/blob/0bef443030919547e9f96bbc0b8d52e0d73a8683/src/main/java/io/vertx/serviceproxy/generator/ServiceProxyHandlerGen.java#L133-L136

As a result, all calls are routed to the first method and fail if arguments mismatch.