### PR TITLE
Added classifier processor to maven vertx-codegen

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -43,6 +43,7 @@ To *implement* service proxies, also add:
   <groupId>${maven.groupId}</groupId>
   <artifactId>vertx-codegen</artifactId>
   <version>${maven.version}</version>
+  <classifier>processor</classifier>
   <scope>provided</scope>
 </dependency>
 ----


### PR DESCRIPTION
Motivation:

It doesn't work otherwise. Tried the simple example of this page on 3 different machines, without the classifier without anything else in the pom, it doesn't work

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
