### PR TITLE
Allow inheritance when registering service binder

### DIFF
--- a/src/main/java/io/vertx/serviceproxy/ServiceBinder.java
+++ b/src/main/java/io/vertx/serviceproxy/ServiceBinder.java
@@ -148,7 +148,7 @@ public class ServiceBinder {
    * @param <T>     the type of the service interface
    * @return the consumer used to unregister the service
    */
-  public <T> MessageConsumer<JsonObject> register(Class<T> clazz, T service) {
+  public <T> MessageConsumer<JsonObject> register(Class<? extends T> clazz, T service) {
     Objects.requireNonNull(address);
     // register
     return getProxyHandler(clazz, service).register(vertx, address, getInterceptorHolders());
@@ -163,7 +163,7 @@ public class ServiceBinder {
    * @param <T>     the type of the service interface
    * @return the consumer used to unregister the service
    */
-  public <T> MessageConsumer<JsonObject> registerLocal(Class<T> clazz, T service) {
+  public <T> MessageConsumer<JsonObject> registerLocal(Class<? extends T> clazz, T service) {
     Objects.requireNonNull(address);
     // register
     return getProxyHandler(clazz, service).registerLocal(vertx, address, getInterceptorHolders());
@@ -209,7 +209,7 @@ public class ServiceBinder {
     currentInterceptorHolders.add(new InterceptorHolder(interceptor));
   }
 
-  private <T> ProxyHandler getProxyHandler(Class<T> clazz, T service) {
+  private <T> ProxyHandler getProxyHandler(Class<? extends T> clazz, T service) {
     String handlerClassName = clazz.getName() + "VertxProxyHandler";
     Class<?> handlerClass = loadClass(handlerClassName, clazz);
     Constructor<?> constructor = getConstructor(


### PR DESCRIPTION
Motivation:

Example:
```
public class Example {

    public static interface Repository<Key, Value> {}

    @ProxyGen
    public static interface UserRepository extends Repository<String, User> {}

    public static class User {}

    public static abstract class AbstractRepositoryVerticle<Key, Value> extends AbstractVerticle implements Repository<Key, Value> {

        private final String address;
        private final Class<? extends Repository<Key, Value>> clazz;

        public AbstractRepositoryVerticle(String address, Class<? extends Repository<Key, Value>> clazz) {
            this.address = address;
            this.clazz = clazz;
        }

        @Override
        public void start() throws Exception {
            new ServiceBinder(vertx).setAddress(address).register(clazz, this);
        }
    }

    public static class UserRepositoryVerticle extends AbstractRepositoryVerticle<String, User> implements UserRepository {
        public UserRepositoryVerticle() {
            super("user-repository", UserRepository.class);
        }
    }

}
```
