### PR TITLE
Introduce grpc-eventbus and service proxy interop tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
   <properties>
     <vertx.surefire.useModulePath>false</vertx.surefire.useModulePath>
     <s>${path.separator}</s>
+    <protobuf.version>4.29.3</protobuf.version>
+    <protobuf.maven.plugin.version>3.10.2</protobuf.maven.plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -97,6 +99,27 @@
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <version>3.3.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-grpc-eventbus</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-grpc-client</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-grpc-server</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -198,6 +221,31 @@
             <id>package-docs</id>
             <goals>
               <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.github.ascopes</groupId>
+        <artifactId>protobuf-maven-plugin</artifactId>
+        <version>${protobuf.maven.plugin.version}</version>
+        <configuration>
+          <protocVersion>${protobuf.version}</protocVersion>
+          <jvmMavenPlugins>
+            <jvmMavenPlugin>
+              <groupId>io.vertx</groupId>
+              <artifactId>vertx-grpc-protoc-plugin2</artifactId>
+              <version>${project.version}</version>
+              <mainClass>io.vertx.grpc.plugin.VertxGrpcGenerator</mainClass>
+              <options>grpc-client=true,grpc-service=true</options>
+            </jvmMavenPlugin>
+          </jvmMavenPlugins>
+        </configuration>
+        <executions>
+          <execution>
+            <id>generate-test</id>
+            <goals>
+              <goal>generate-test</goal>
             </goals>
           </execution>
         </executions>

--- a/src/test/java/io/vertx/serviceproxy/tests/grpcinterop/EventBusServiceProxyInteropTest.java
+++ b/src/test/java/io/vertx/serviceproxy/tests/grpcinterop/EventBusServiceProxyInteropTest.java
@@ -1,0 +1,211 @@
+package io.vertx.serviceproxy.tests.grpcinterop;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.core.eventbus.DeliveryOptions;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.eventbus.ReplyException;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.grpc.client.InvalidStatusException;
+import io.vertx.grpc.common.GrpcStatus;
+import io.vertx.grpc.common.WireFormat;
+import io.vertx.grpc.eventbus.EventBusGrpcClient;
+import io.vertx.grpc.eventbus.EventBusGrpcServer;
+import io.vertx.serviceproxy.ServiceBinder;
+import io.vertx.serviceproxy.ServiceException;
+import io.vertx.serviceproxy.ServiceProxyBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.*;
+
+@RunWith(VertxUnitRunner.class)
+public class EventBusServiceProxyInteropTest {
+
+  private static final String ADDRESS = "proxyinterop.Greeter";
+
+  protected Vertx vertx;
+
+  @Before
+  public void setUp() {
+    vertx = Vertx.vertx();
+  }
+
+  @After
+  public void tearDown(TestContext should) {
+    vertx.close().onComplete(should.asyncAssertSuccess());
+  }
+
+  @Test
+  public void testProxyClientCallsGrpcServer() throws Exception {
+    EventBusGrpcServer server = EventBusGrpcServer.server(vertx);
+    server.addService(GreeterGrpcService.of(new GreeterService() {
+      @Override
+      public Future<HelloReply> sayHello(HelloRequest request) {
+        return Future.succeededFuture(HelloReply.newBuilder()
+          .setMessage("Hello " + request.getName())
+          .build());
+      }
+
+      @Override
+      public Future<HelloReply> sayHi(HelloRequest request) {
+        return Future.succeededFuture(HelloReply.newBuilder()
+          .setMessage("Hi " + request.getName())
+          .build());
+      }
+    }));
+
+    GreeterProxy proxy = new ServiceProxyBuilder(vertx)
+      .setAddress(ADDRESS)
+      .setOptions(new DeliveryOptions().addHeader("grpc-wire-format", WireFormat.JSON.name()))
+      .build(GreeterProxy.class);
+
+    HelloJavaReply reply = proxy.SayHello("Julien").await(10, TimeUnit.SECONDS);
+    assertEquals("Hello Julien", reply.getMessage());
+
+    HelloJavaReply lowerReply = proxy.sayHi("Julien").await(10, TimeUnit.SECONDS);
+    assertEquals("Hi Julien", lowerReply.getMessage());
+  }
+
+  @Test
+  public void testGrpcClientCallsProxyServer() throws Exception {
+    GreeterProxy impl = new GreeterProxy() {
+      @Override
+      public Future<HelloJavaReply> SayHello(String name) {
+        return Future.succeededFuture(new HelloJavaReply().setMessage("Hello " + name));
+      }
+
+      @Override
+      public Future<HelloJavaReply> sayHi(String name) {
+        return Future.succeededFuture(new HelloJavaReply().setMessage("Hi " + name));
+      }
+    };
+    MessageConsumer<JsonObject> consumer = new ServiceBinder(vertx)
+      .setAddress(ADDRESS)
+      .register(GreeterProxy.class, impl);
+
+    try {
+      EventBusGrpcClient client = EventBusGrpcClient.client(vertx);
+      GreeterClient greeter = GreeterGrpcClient.create(client, WireFormat.JSON);
+
+      HelloReply reply = greeter
+        .sayHello(HelloRequest.newBuilder().setName("Julien").build())
+        .await(10, TimeUnit.SECONDS);
+      assertEquals("Hello Julien", reply.getMessage());
+
+      HelloReply lowerReply = greeter
+        .sayHi(HelloRequest.newBuilder().setName("Julien").build())
+        .await(10, TimeUnit.SECONDS);
+      assertEquals("Hi Julien", lowerReply.getMessage());
+    } finally {
+      consumer.unregister().await(10, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  public void testProxyClientReceivesGrpcServerFailure() {
+    EventBusGrpcServer server = EventBusGrpcServer.server(vertx);
+    server.addService(GreeterGrpcService.of(new GreeterService() {
+      @Override
+      public Future<HelloReply> sayHello(HelloRequest request) {
+        return Future.failedFuture(new RuntimeException("boom"));
+      }
+    }));
+
+    GreeterProxy proxy = new ServiceProxyBuilder(vertx)
+      .setAddress(ADDRESS)
+      .setOptions(new DeliveryOptions().addHeader("grpc-wire-format", WireFormat.JSON.name()))
+      .build(GreeterProxy.class);
+
+    ReplyException expected = assertThrows(ReplyException.class, () -> proxy.SayHello("Julien").await(10, TimeUnit.SECONDS));
+    assertEquals(GrpcStatus.UNKNOWN.code, expected.failureCode());
+  }
+
+  @Test
+  public void testGrpcClientReceivesProxyServerServiceException() throws Exception {
+    GreeterProxy impl = new GreeterProxy() {
+      @Override
+      public Future<HelloJavaReply> SayHello(String name) {
+        return Future.failedFuture(new ServiceException(GrpcStatus.NOT_FOUND.code, "nope"));
+      }
+
+      @Override
+      public Future<HelloJavaReply> sayHi(String name) {
+        return Future.failedFuture(new ServiceException(GrpcStatus.NOT_FOUND.code, "nope"));
+      }
+    };
+    MessageConsumer<JsonObject> consumer = new ServiceBinder(vertx)
+      .setAddress(ADDRESS)
+      .register(GreeterProxy.class, impl);
+
+    try {
+      EventBusGrpcClient client = EventBusGrpcClient.client(vertx);
+      GreeterClient greeter = GreeterGrpcClient.create(client, WireFormat.JSON);
+
+      InvalidStatusException expected = assertThrows(
+        InvalidStatusException.class, () -> greeter.sayHello(HelloRequest.newBuilder().setName("Julien").build()).await(10, TimeUnit.SECONDS)
+      );
+      assertEquals(GrpcStatus.NOT_FOUND, expected.actualStatus());
+    } finally {
+      consumer.unregister().await(10, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  public void testGrpcClientReceivesProxyServerRuntimeFailureAsInternal() throws Exception {
+    GreeterProxy impl = new GreeterProxy() {
+      @Override
+      public Future<HelloJavaReply> SayHello(String name) {
+        return Future.failedFuture(new RuntimeException("kaboom"));
+      }
+
+      @Override
+      public Future<HelloJavaReply> sayHi(String name) {
+        return Future.failedFuture(new RuntimeException("kaboom"));
+      }
+    };
+    MessageConsumer<JsonObject> consumer = new ServiceBinder(vertx)
+      .setAddress(ADDRESS)
+      .register(GreeterProxy.class, impl);
+
+    try {
+      EventBusGrpcClient client = EventBusGrpcClient.client(vertx);
+      GreeterClient greeter = GreeterGrpcClient.create(client, WireFormat.JSON);
+
+      InvalidStatusException expected = assertThrows(
+        InvalidStatusException.class, () -> greeter.sayHello(HelloRequest.newBuilder().setName("Julien").build()).await(10, TimeUnit.SECONDS)
+      );
+      assertEquals(GrpcStatus.INTERNAL, expected.actualStatus());
+    } finally {
+      consumer.unregister().await(10, TimeUnit.SECONDS);
+    }
+  }
+
+  @Test
+  public void testProxyClientWithoutWireFormatHeaderFails() {
+    EventBusGrpcServer server = EventBusGrpcServer.server(vertx);
+    server.addService(GreeterGrpcService.of(new GreeterService() {
+      @Override
+      public Future<HelloReply> sayHello(HelloRequest request) {
+        return Future.succeededFuture(HelloReply.newBuilder()
+          .setMessage("Hello " + request.getName())
+          .build());
+      }
+    }));
+
+    GreeterProxy proxy = new ServiceProxyBuilder(vertx)
+      .setAddress(ADDRESS)
+      .build(GreeterProxy.class);
+
+    ReplyException expected = assertThrows(ReplyException.class, () -> proxy.SayHello("Julien").await(10, TimeUnit.SECONDS));
+    assertEquals(GrpcStatus.INVALID_ARGUMENT.code, expected.failureCode());
+    assertNotNull(expected.getMessage());
+    assertTrue("expected message to mention grpc-wire-format, got: " + expected.getMessage(), expected.getMessage().contains("grpc-wire-format"));
+  }
+}

--- a/src/test/java/io/vertx/serviceproxy/tests/grpcinterop/GreeterProxy.java
+++ b/src/test/java/io/vertx/serviceproxy/tests/grpcinterop/GreeterProxy.java
@@ -1,0 +1,16 @@
+package io.vertx.serviceproxy.tests.grpcinterop;
+
+import io.vertx.codegen.annotations.ProxyGen;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+
+@ProxyGen
+@VertxGen
+public interface GreeterProxy {
+
+  @SuppressWarnings("checkstyle:MethodName")
+  Future<HelloJavaReply> SayHello(String name);
+
+  Future<HelloJavaReply> sayHi(String name);
+
+}

--- a/src/test/java/io/vertx/serviceproxy/tests/grpcinterop/HelloJavaReply.java
+++ b/src/test/java/io/vertx/serviceproxy/tests/grpcinterop/HelloJavaReply.java
@@ -1,0 +1,34 @@
+package io.vertx.serviceproxy.tests.grpcinterop;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+@DataObject
+public class HelloJavaReply {
+
+  private String message;
+
+  public HelloJavaReply() {
+  }
+
+  public HelloJavaReply(JsonObject json) {
+    this.message = json.getString("message");
+  }
+
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    if (message != null) {
+      json.put("message", message);
+    }
+    return json;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public HelloJavaReply setMessage(String message) {
+    this.message = message;
+    return this;
+  }
+}

--- a/src/test/java/io/vertx/serviceproxy/tests/grpcinterop/package-info.java
+++ b/src/test/java/io/vertx/serviceproxy/tests/grpcinterop/package-info.java
@@ -1,0 +1,4 @@
+@ModuleGen(name = "grpc-proxy-interop", groupPackage = "io.vertx.serviceproxy.tests.grpcinterop")
+package io.vertx.serviceproxy.tests.grpcinterop;
+
+import io.vertx.codegen.annotations.ModuleGen;

--- a/src/test/proto/proxy_interop.proto
+++ b/src/test/proto/proxy_interop.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "io.vertx.serviceproxy.tests.grpcinterop";
+option java_outer_classname = "ProxyInteropProto";
+
+package proxyinterop;
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+  rpc sayHi (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 1;
+}


### PR DESCRIPTION
Motivation:
Add test coverage for the interoperability between grpc-eventbus and service proxy

Changes:
- Added protobuf definitions for the interop tests.
- Introduced grpc-eventbus-client, grpc-eventbus-server, and related dependencies to `pom.xml`.
- Implemented `GreeterProxy` interface and supporting data classes.
- Added test suite validating interoperability scenarios.
